### PR TITLE
Build on ARM for the process id register assembly.

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -594,9 +594,9 @@ get_thread_id(void) {
 #  elif defined(__x86_64__)
 	__asm__("movq %%fs:0, %0" : "=r" (tid) : : );
 #  elif defined(__arm__)
-	asm volatile ("mrc p15, 0, %0, c13, c0, 3" : "=r" (tid));
+	__asm__ volatile ("mrc p15, 0, %0, c13, c0, 3" : "=r" (tid));
 #  elif defined(__aarch64__)
-	asm volatile ("mrs %0, tpidr_el0" : "=r" (tid));
+	__asm__ volatile ("mrs %0, tpidr_el0" : "=r" (tid));
 #  else
 	tid = (uintptr_t)get_thread_heap_raw();
 #  endif


### PR DESCRIPTION
asm token not recognised by none of the compilers (raspberry).