### PR TITLE
Cmake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ cov-int.*
 [Rr]elease/
 [Pp]rofile/
 [Dd]eploy/
+CMakeBuilds/
 *_i.c
 *_p.c
 *.ilk

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ cov-int.*
 *.sln.docstates
 
 # Build results
+.vs/
 [Dd]ebug/
 [Rr]elease/
 [Pp]rofile/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,25 @@ cmake_minimum_required (VERSION 3.8)
 project(RpMalloc)
 
 option(BUILD_RPMALLOC_TEST "Build rpmalloc-test." ON)
+option(RPMALLOC_ENABLE_STATISTICS "Build rpmalloc with Statics on." OFF)
+option(RPMALLOC_ENABLE_ASSERTS "Build rpmalloc with Asserts on." OFF)
+option(RPMALLOC_ENABLE_ARGUMENT_VALIDATION "Build RPMalloc with Argument Validation" OFF)
+
 
 add_library(RpMallocStatic STATIC "rpmalloc/rpmalloc.c" "rpmalloc/rpmalloc.h")
 target_include_directories(RpMallocStatic PUBLIC rpmalloc )
 
+if(RPMALLOC_ENABLE_STATISTICS)
+	target_compile_definitions(RpMallocStatic  PRIVATE "ENABLE_STATISTICS=1")
+endif(RPMALLOC_ENABLE_STATISTICS)
+
+if(RPMALLOC_ENABLE_ASSERTS)
+	target_compile_definitions(RpMallocStatic  PRIVATE "ENABLE_ASSERTS=1")
+endif(RPMALLOC_ENABLE_ASSERTS)
+
+if(RPMALLOC_ENABLE_ARGUMENT_VALIDATION)
+	target_compile_definitions(RpMallocStatic  PRIVATE "ENABLE_VALIDATE_ARGS=1")
+endif(RPMALLOC_ENABLE_ARGUMENT_VALIDATION)
 
 if(BUILD_RPMALLOC_TEST)
 	set(RPMALLOC_TEST_SOURCES 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required (VERSION 3.8)
+
+project(RpMalloc)
+
+option(BUILD_RPMALLOC_TEST "Build rpmalloc-test." ON)
+
+add_library(RpMallocStatic STATIC "rpmalloc/rpmalloc.c" "rpmalloc/rpmalloc.h")
+target_include_directories(RpMallocStatic PUBLIC rpmalloc )
+
+
+if(BUILD_RPMALLOC_TEST)
+	set(RPMALLOC_TEST_SOURCES 
+		"test/main.c"
+		"test/test.h"
+		"test/thread.c"
+		"test/thread.h"
+	)
+
+
+	add_executable (rpmalloc_test ${RPMALLOC_TEST_SOURCES})
+	target_include_directories(rpmalloc_test  PUBLIC test )
+
+	target_link_libraries(rpmalloc_test RpMallocStatic)
+endif(BUILD_RPMALLOC_TEST)

--- a/CmakeSettings.json
+++ b/CmakeSettings.json
@@ -1,0 +1,90 @@
+{
+  /* Begin 64-bit x86 configurations
+	 * See: https://docs.microsoft.com/en-us/cpp/build/cmake-predefined-configuration-reference?view=vs-2017
+	 */
+  "environments": [
+    {
+      "DebugBuildDir": "${projectDir}\\CMakeBuilds\\Debug\\${name}\\${workspaceHash}",
+      "installRoot": "${projectDir}\\bin\\${name}",
+      "buildRoot": "${projectDir}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      //"installRoot": "${projectDir}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }
+  ],
+  "configurations": [
+
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
+      "cmakeCommandArgs": "",
+      "buildRoot": "${env.DebugBuildDir}",
+      "installRoot": "${env.installRoot}",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
+      "cmakeCommandArgs": "",
+      "buildRoot": "${env.DebugBuildDir}",
+      "installRoot": "${env.installRoot}",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-DebugRelease",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
+      "cmakeCommandArgs": "",
+      "buildRoot": "${env.DebugBuildDir}",
+      "installRoot": "${env.installRoot}",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "cmakeCommandArgs": "",
+      "buildRoot": "${env.DebugBuildDir}",
+      "installRoot": "${env.installRoot}",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x86-DebugRelease",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/CmakeSettings.json
+++ b/CmakeSettings.json
@@ -5,8 +5,9 @@
   "environments": [
     {
       "DebugBuildDir": "${projectDir}\\CMakeBuilds\\Debug\\${name}\\${workspaceHash}",
+      "ReleaseBuildDir": "${projectDir}\\CMakeBuilds\\Release\\${name}\\${workspaceHash}",
       "installRoot": "${projectDir}\\bin\\${name}",
-      "buildRoot": "${projectDir}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "buildRoot": "${projectDir}\\CMakeBuilds\\${workspaceHash}\\build\\${name}"
       //"installRoot": "${projectDir}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
     }
   ],
@@ -33,7 +34,7 @@
         "msvc_x64_x64"
       ],
       "cmakeCommandArgs": "",
-      "buildRoot": "${env.DebugBuildDir}",
+      "buildRoot": "${env.ReleaseBuildDir}",
       "installRoot": "${env.installRoot}",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
@@ -46,7 +47,7 @@
         "msvc_x64_x64"
       ],
       "cmakeCommandArgs": "",
-      "buildRoot": "${env.DebugBuildDir}",
+      "buildRoot": "${env.ReleaseBuildDir}",
       "installRoot": "${env.installRoot}",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
@@ -72,6 +73,8 @@
         "msvc_x86"
       ],
       "cmakeCommandArgs": "",
+      "buildRoot": "${env.ReleaseBuildDir}",
+      "installRoot": "${env.installRoot}",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -83,6 +86,8 @@
         "msvc_x86"
       ],
       "cmakeCommandArgs": "",
+      "buildRoot": "${env.ReleaseBuildDir}",
+      "installRoot": "${env.installRoot}",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     }


### PR DESCRIPTION
This build option works on Visual Studio 2017 or newer. The default configuration uses ninja build system and will generate multiple builds with relative ease.

For more information see the following:
Visual Studio 2017:
https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2017

Visual Studio 2019:
https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019