### PR TITLE
Fix windows include on mingw-w64

### DIFF
--- a/test/main-override.cc
+++ b/test/main-override.cc
@@ -131,7 +131,7 @@ main(int argc, char** argv) {
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 
 static void
 test_initialize(void) {

--- a/test/main.c
+++ b/test/main.c
@@ -843,7 +843,7 @@ main(int argc, char** argv) {
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 
 static void
 test_initialize(void) {

--- a/test/thread.c
+++ b/test/thread.c
@@ -8,7 +8,7 @@
 #endif
 
 #ifdef _WIN32
-#  include <Windows.h>
+#  include <windows.h>
 #  include <process.h>
 
 static unsigned __stdcall


### PR DESCRIPTION
mingw-w64 is case sensitive for include files when cross compiling on Linux, this fixes the compile error:

```
rpmalloc/rpmalloc.c:123:12: fatal error: Windows.h: No such file or directory
  123 | #  include <Windows.h>
```
