### PR TITLE
Fix a bug retry on sleep logic

### DIFF
--- a/test/thread.c
+++ b/test/thread.c
@@ -86,10 +86,8 @@ thread_sleep(int milliseconds) {
 	ts.tv_sec  = milliseconds / 1000;
 	ts.tv_nsec = (long)(milliseconds % 1000) * 1000000L;
 
-	while (nanosleep(&ts, &remaining) != 0) {
-		if (errno == EINTR)
-			ts = remaining;
-	}
+	while (nanosleep(&ts, &remaining) != 0 && errno == EINTR)
+		ts = remaining;
 #endif
 }
 


### PR DESCRIPTION
I just realized that there's a bug in my previous PR (#190).

If nanosleep fails for something other than EINTR, it could potentially enter an infinite loop.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>