### PR TITLE
Initialize heap_t struct after allocate it

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -1627,6 +1627,7 @@ _rpmalloc_heap_extract_new_span(heap_t* heap, size_t span_count, uint32_t class_
 
 static void
 _rpmalloc_heap_initialize(heap_t* heap) {
+	memset(heap, 0, sizeof(heap_t));
 	//Get a new heap ID
 	heap->id = 1 + atomic_incr32(&_memory_heap_id);
 


### PR DESCRIPTION
Use `memset()` to initialize all fields in `heap_t`.

Fix #192 