### PR TITLE
docs: fix simple typo, imlemented -> implemented

### DIFF
--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -284,7 +284,7 @@ rpmalloc_usable_size(void* ptr);
 typedef struct heap_t rpmalloc_heap_t;
 
 //! Acquire a new heap. Will reuse existing released heaps or allocate memory for a new heap
-//  if none available. Heap API is imlemented with the strict assumption that only one single
+//  if none available. Heap API is implemented with the strict assumption that only one single
 //  thread will call heap functions for a given heap at any given time, no functions are thread safe.
 RPMALLOC_EXPORT rpmalloc_heap_t*
 rpmalloc_heap_acquire(void);


### PR DESCRIPTION
There is a small typo in rpmalloc/rpmalloc.h.

Should read `implemented` rather than `imlemented`.

