### PR TITLE
Fix minor implicit conversion errors.

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -1454,7 +1454,7 @@ _rpmalloc_heap_global_finalize(heap_t* heap) {
 		}
 	}
 	//Heap is now completely free, unmap and remove from heap list
-	size_t list_idx = heap->id % HEAP_ARRAY_SIZE;
+	size_t list_idx = (size_t)heap->id % HEAP_ARRAY_SIZE;
 	heap_t* list_heap = _memory_heaps[list_idx];
 	if (list_heap == heap) {
 		_memory_heaps[list_idx] = heap->next_heap;
@@ -1637,7 +1637,7 @@ _rpmalloc_heap_initialize(heap_t* heap) {
 	heap->id = 1 + atomic_incr32(&_memory_heap_id);
 
 	//Link in heap in heap ID map
-	size_t list_idx = heap->id % HEAP_ARRAY_SIZE;
+	size_t list_idx = (size_t)heap->id % HEAP_ARRAY_SIZE;
 	heap->next_heap = _memory_heaps[list_idx];
 	_memory_heaps[list_idx] = heap;
 }


### PR DESCRIPTION
Fix a minor conversion error that prevents the library from being
compiled with very recent versions of Clang, which provide -Wconversion,
enabled as part of -Weverything (as set by the rpmalloc build).

The issue was that heap->id is an int32_t value, so the compiler was
complaining that the code was trying to implicitly convert a signed
32-bit integer into an unsigned 64-bit one.