### PR TITLE
DragonFlyBSD support.

### DIFF
--- a/build/ninja/platform.py
+++ b/build/ninja/platform.py
@@ -20,7 +20,7 @@ class Platform(object):
       self.platform = 'macos'
     elif self.platform.startswith('win'):
       self.platform = 'windows'
-    elif 'bsd' in self.platform:
+    elif 'bsd' in self.platform or self.platform.startswith('dragonfly'):
       self.platform = 'bsd'
     elif self.platform.startswith('ios'):
       self.platform = 'ios'

--- a/rpmalloc/malloc.c
+++ b/rpmalloc/malloc.c
@@ -397,7 +397,8 @@ pthread_create(pthread_t* thread,
                const pthread_attr_t* attr,
                void* (*start_routine)(void*),
                void* arg) {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(__HAIKU__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFLy__) || \
+    defined(__APPLE__) || defined(__HAIKU__)
 	char fname[] = "pthread_create";
 #else
 	char fname[] = "_pthread_create";


### PR DESCRIPTION
the system does not contain BSD keyword but is truly one.
asking proper pthread symbol too.