### PR TITLE
Fix macro expansion for clang due to musl based distros.

### DIFF
--- a/build/ninja/clang.py
+++ b/build/ninja/clang.py
@@ -52,7 +52,7 @@ class ClangToolchain(toolchain.Toolchain):
                    '-fno-trapping-math', '-ffast-math']
     self.cwarnflags = ['-W', '-Werror', '-pedantic', '-Wall', '-Weverything',
                        '-Wno-c++98-compat', '-Wno-padded', '-Wno-documentation-unknown-command',
-                       '-Wno-implicit-fallthrough', '-Wno-static-in-inline', '-Wno-reserved-id-macro']
+                       '-Wno-implicit-fallthrough', '-Wno-static-in-inline', '-Wno-reserved-id-macro', '-Wno-disabled-macro-expansion']
     self.cmoreflags = []
     self.mflags = []
     self.arflags = []


### PR DESCRIPTION
gcc does not have this issue, the "problematic" macro
 was #define stderr (stderr)