### PR TITLE
On Darwin using MADV_FREE_REUSABLE to notify the system

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -866,6 +866,9 @@ _rpmalloc_unmap_os(void* address, size_t size, size_t offset, size_t release) {
 			assert("Failed to unmap virtual memory block" == 0);
 		}
 	} else {
+#if defined(MADV_FREE_REUSABLE)
+		if (madvise(address, size, MADV_FREE_REUSABLE))
+#endif
 #if defined(POSIX_MADV_FREE)
 		if (posix_madvise(address, size, POSIX_MADV_FREE))
 #endif


### PR DESCRIPTION
those pages can be reused at will by other needs.
Thus, the memory usage reported by the OS decreases to the expected amount.

Before change, rpmalloc-test the sample utility reported about 692 MB,
 after this chang it is about 305 MB.