### PR TITLE
Fixed get_thread_id for iOS simulator

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -707,7 +707,7 @@ get_thread_id(void) {
 #  if defined(__i386__)
 	__asm__("movl %%gs:0, %0" : "=r" (tid) : : );
 #  elif defined(__x86_64__)
-#    if defined(__MACH__) && !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+#    if defined(__MACH__)
 	__asm__("movq %%gs:0, %0" : "=r" (tid) : : );
 #    else
 	__asm__("movq %%fs:0, %0" : "=r" (tid) : : );


### PR DESCRIPTION
The iOS simulator runs binaries under the Mach kernel, which maps thread specific memory using the GS register.
The old code used FS instead which caused a null pointer dereference when debugging in the simulator. I think this bug was introduced in #172 to fix a compile error when targeting ARM.