### PR TITLE
fix(deferred): adopt the deferred span cache list when span_count != 1

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -1563,11 +1563,6 @@ _rpmalloc_heap_cache_insert(heap_t* heap, span_t* span) {
 static span_t*
 _rpmalloc_heap_thread_cache_extract(heap_t* heap, size_t span_count) {
 	span_t* span = 0;
-	if (span_count == 1) {
-		_rpmalloc_heap_cache_adopt_deferred(heap, &span);
-		if (span)
-			return span;
-	}
 #if ENABLE_THREAD_CACHE
 	span_cache_t* span_cache;
 	if (span_count == 1)
@@ -1579,6 +1574,18 @@ _rpmalloc_heap_thread_cache_extract(heap_t* heap, size_t span_count) {
 		return span_cache->span[--span_cache->count];
 	}
 #endif
+	return span;
+}
+
+static span_t*
+_rpmalloc_heap_thread_cache_deferred_extract(heap_t* heap, size_t span_count) {
+	span_t* span = 0;
+	if (span_count == 1) {
+		_rpmalloc_heap_cache_adopt_deferred(heap, &span);
+	} else {
+		_rpmalloc_heap_cache_adopt_deferred(heap, 0);
+		span = _rpmalloc_heap_thread_cache_extract(heap, span_count);
+	}
 	return span;
 }
 
@@ -1650,6 +1657,11 @@ _rpmalloc_heap_extract_new_span(heap_t* heap, size_t span_count, uint32_t class_
 	(void)sizeof(class_idx);
 #endif
 	span = _rpmalloc_heap_thread_cache_extract(heap, span_count);
+	if (EXPECTED(span != 0)) {
+		_rpmalloc_stat_inc(&heap->size_class_use[class_idx].spans_from_cache);
+		return span;
+	}
+	span = _rpmalloc_heap_thread_cache_deferred_extract(heap, span_count);
 	if (EXPECTED(span != 0)) {
 		_rpmalloc_stat_inc(&heap->size_class_use[class_idx].spans_from_cache);
 		return span;
@@ -2028,6 +2040,7 @@ _rpmalloc_allocate_large(heap_t* heap, size_t size) {
 static void*
 _rpmalloc_allocate_huge(heap_t* heap, size_t size) {
 	assert(heap);
+	_rpmalloc_heap_cache_adopt_deferred(heap, 0);
 	size += SPAN_HEADER_SIZE;
 	size_t num_pages = size >> _memory_page_size_shift;
 	if (size & (_memory_page_size - 1))


### PR DESCRIPTION
In the current version, rpmalloc will adopt deferred span cache list if
and only if the span_count == 1. This may cause memory leak in some
situations where the allocator thread allocate large blocks only and the
block is freed in another thread. So we try to adopt the deferred list
even when span_count != 1.

Besides, we also adopt deferred list when allocating huge blocks for the
same reason.