### PR TITLE
Use __ARM_ARCH macro without trailing underscores

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -757,7 +757,7 @@ _rpmalloc_spin(void) {
 	_mm_pause();
 #elif defined(__x86_64__) || defined(__i386__)
 	__asm__ volatile("pause" ::: "memory");
-#elif defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH__ >= 7)
+#elif defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH >= 7)
 	__asm__ volatile("yield" ::: "memory");
 #elif defined(__powerpc__) || defined(__powerpc64__)
         // No idea if ever been compiled in such archs but ... as precaution


### PR DESCRIPTION
As defined by ARM toolchains, see https://godbolt.org/z/536hzj
I believe `__ARM_ARCH__` with trailing underscores is only defined in some platform-specific header files, derived from `__ARM_ARCH_xy__` macros for the specific architecture, but I'm not 100% sure. Yet I've seen the `__ARM_ARCH` variety pre-defined by all ARMv7 toolchains I tested, without the need for any system includes.