### PR TITLE
Missing extern "C" 

### DIFF
--- a/rpmalloc/malloc.c
+++ b/rpmalloc/malloc.c
@@ -314,9 +314,17 @@ initializer(void) {
 
 #elif defined(_MSC_VER)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #pragma section(".CRT$XIB",read)
 __declspec(allocate(".CRT$XIB")) void (*_rpmalloc_module_init)(void) = _global_rpmalloc_init;
 #pragma comment(linker, "/include:_rpmalloc_module_init")
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
When preloading on Windows, there is a linker error because an extern "C" is missing

`libs.cpp.obj : error LNK2001: unresolved external symbol _rpmalloc_module_init
Hint on symbols that are defined and could potentially match:
"void (__cdecl* _rpmalloc_module_init)(void)" (?_rpmalloc_module_init@@3P6AXXZEA)`
