### PR TITLE
Cross thread allocation/deallocation bug test + potential fixes

### DIFF
--- a/build/ninja/msvc.py
+++ b/build/ninja/msvc.py
@@ -32,7 +32,7 @@ class MSVCToolchain(toolchain.Toolchain):
     self.dllcmd = self.linkcmd + ' /DLL'
 
     self.cflags = ['/D', '"' + project.upper() + '_COMPILE=1"', '/D', '"_UNICODE"',  '/D', '"UNICODE"', '/std:c17', '/Zi', '/Oi', '/Oy-', '/GS-', '/Gy-', '/Qpar-', '/fp:fast', '/fp:except-', '/Zc:forScope', '/Zc:wchar_t', '/GR-', '/openmp-']
-    self.cwarnflags = ['/W4', '/WX', '/wd4201'] #Ignore nameless union/struct which is allowed in C11
+    self.cwarnflags = ['/W4', '/WX', '/wd4201', '/wd4530'] #Ignore nameless union/struct which is allowed in C11
     self.cmoreflags = []
     self.arflags = ['/ignore:4221'] #Ignore empty object file warning]
     self.linkflags = ['/DEBUG']

--- a/configure.py
+++ b/configure.py
@@ -22,3 +22,4 @@ if not generator.target.is_android() and not generator.target.is_ios():
 
 	generator.bin(module = 'test', sources = ['thread.c', 'main.c'], binname = 'rpmalloc-test', implicit_deps = [rpmalloc_test_lib], libs = ['rpmalloc-test'], includepaths = ['rpmalloc', 'test'], variables = {'defines': ['ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1', 'RPMALLOC_FIRST_CLASS_HEAPS=1', 'RPMALLOC_CONFIGURABLE=1']})
 	generator.bin(module = 'test', sources = ['thread.c', 'main-override.cc'], binname = 'rpmallocwrap-test', implicit_deps = [rpmallocwrap_lib], libs = ['rpmallocwrap'], includepaths = ['rpmalloc', 'test'], variables = {'runtime': 'c++', 'defines': ['ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1']})
+	generator.bin(module = 'test', sources = ['bug.cc'], binname = 'bug-test', implicit_deps = [rpmallocwrap_lib], libs = ['rpmallocwrap'], includepaths = ['rpmalloc', 'test'], variables = {'runtime': 'c++'})

--- a/test/bug.cc
+++ b/test/bug.cc
@@ -1,0 +1,116 @@
+#include <rpmalloc.h>
+#include <rpnew.h>
+
+#include <atomic>
+#include <functional>
+#include <future>
+#include <iostream>
+#include <mutex>
+#include <stack>
+#include <thread>
+#include <vector>
+
+typedef std::function<void()> Functor;
+
+struct WorkStack {
+  std::atomic<bool> stop{false};
+  std::mutex mutex;
+  std::condition_variable cond;
+  std::stack<Functor> stack;
+  std::vector<std::thread> threads;
+
+  WorkStack(uint32_t num) {
+    for (uint32_t i = 0; i < num; ++i)
+      threads.emplace_back([this] { work(); });
+  }
+
+  ~WorkStack() {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stop = true;
+    }
+    cond.notify_all();
+    for (auto &t : threads)
+      t.join();
+  }
+
+  void add(Functor f) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stack.push(f);
+    }
+    cond.notify_one();
+  }
+
+  void work() {
+    while (true) {
+      std::unique_lock<std::mutex> lock(mutex);
+      cond.wait(lock, [&] { return stop || !stack.empty(); });
+      if (stop)
+        break;
+      auto f = stack.top();
+      stack.pop();
+      lock.unlock();
+      f();
+    }
+  }
+};
+
+struct Job {
+  Functor f;
+
+  void work() {
+    f();
+    f = {};
+  }
+};
+
+struct Latch {
+  std::promise<void> promise;
+  std::atomic<uint32_t> count;
+
+  Latch(uint32_t c) : count(c) {}
+  ~Latch() { promise.get_future().wait(); }
+
+  void dec() {
+    if (--count == 0)
+      promise.set_value();
+  }
+};
+
+int main(int, char **) {
+  const uint32_t numThreads = 24;
+  const uint32_t batchSize = 256;
+  const uint32_t numJobs = batchSize * (numThreads * 32) - 1;
+
+  size_t global = 0;
+  WorkStack st(numThreads);
+
+  uint32_t iteration = 0;
+  std::vector<Job> jobs(numJobs);
+  std::function<void(uint32_t)> func = [&](uint32_t i) { jobs[i].work(); };
+  do {
+    uint32_t i;
+    for (i = 0; i < numJobs; ++i)
+      jobs[i].f = [&] { ++global; };
+
+    const uint32_t num = numJobs / batchSize;
+    Latch l(num);
+    uint32_t j;
+    for (i = 0, j = batchSize; j < numJobs; i = j, j += batchSize) {
+      st.add([=, &l] {
+        for (uint32_t k = i; k < j; ++k)
+          func(k);
+        l.dec();
+      });
+    }
+
+    for (; i < numJobs; ++i)
+      jobs[i].work();
+
+    if (++iteration % 256 == 0)
+      std::cout << iteration << '.';
+  } while (true);
+
+  return 0;
+}


### PR DESCRIPTION
An unsynchronised access of span->list_size in
_rpmalloc_deallocate_direct_small_or_medium can result in a span being
recycled and put back into use before the store of
span->free_list_deferred occurs in the call to
_rpmalloc_deallocate_defer_small_or_medium that initially "freed" this
span. The eventual store of span->free_list_deferred corrupts the span
resulting in crashes.

This patch adds an artificial delay between the increment of
span->list_size and the store of span->free_list_deferred to make
reproduction of the issue more likely and thus faster with the included
test case.

Two potential fixes are also included.