### PR TITLE
clang-cl: Use builtin intrinsics for clang-cl as well

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -31,7 +31,7 @@
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #if !defined(__has_builtin)
 #define __has_builtin(b) 0
 #endif


### PR DESCRIPTION
clang-cl doesn't define GNUC but it does define __clang__. So
check for both when deciding if we should use the builtin inline memcpy
