### PR TITLE
Fix compatibility with Clang 15

### DIFF
--- a/build/ninja/clang.py
+++ b/build/ninja/clang.py
@@ -47,7 +47,7 @@ class ClangToolchain(toolchain.Toolchain):
 
     #Base flags
     self.cflags = ['-D' + project.upper() + '_COMPILE=1',
-                   '-funit-at-a-time', '-fstrict-aliasing', '-fvisibility=default', '-fno-stack-protector',
+                   '-fstrict-aliasing', '-fvisibility=default', '-fno-stack-protector',
                    '-fno-math-errno','-ffinite-math-only', '-funsafe-math-optimizations',
                    '-fno-trapping-math', '-ffast-math']
     self.cwarnflags = ['-W', '-Werror', '-pedantic', '-Wall', '-Weverything',


### PR DESCRIPTION
In Clang 15 `-funit-at-a-time` gives the following error:

```
clang-15: error: optimization flag '-funit-at-a-time' is not supported [-Werror,-Wignored-optimization-argument]
```

This flag doesn't do anything in clang even before, so we can drop it without any problems.