### PR TITLE
Add "rpmalloc_get_heap_for_ptr"

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -3590,6 +3590,18 @@ rpmalloc_heap_thread_set_current(rpmalloc_heap_t* heap) {
 	}
 }
 
+extern inline rpmalloc_heap_t*
+rpmalloc_get_heap_for_ptr(void* ptr)
+{
+	//Grab the span, and then the heap from the span
+	span_t* span = (span_t*)((uintptr_t)ptr & _memory_span_mask);
+	if (span)
+	{
+		return span->heap;
+	}
+	return 0;
+}
+
 #endif
 
 #if ENABLE_PRELOAD || ENABLE_OVERRIDE

--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -362,6 +362,10 @@ rpmalloc_heap_free_all(rpmalloc_heap_t* heap);
 RPMALLOC_EXPORT void
 rpmalloc_heap_thread_set_current(rpmalloc_heap_t* heap);
 
+//! Returns which heap the given pointer is allocated on
+RPMALLOC_EXPORT rpmalloc_heap_t*
+rpmalloc_get_heap_for_ptr(void* ptr);
+
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Adding a new API call which allows for querying which first-class heap a given address was allocated on. This is useful when doing reallocs or frees in an environment that uses a mixture of thread-local and manually-managed first-class heaps, by being able to find what the source heap for an allocation was, and deciding what behaviour should be performed in light of that.