### PR TITLE
Properly release span cache on free all

### DIFF
--- a/rpmalloc/malloc.c
+++ b/rpmalloc/malloc.c
@@ -274,6 +274,9 @@ _rpmalloc_page_size(void) {
 }
 
 extern void* RPMALLOC_CDECL
+reallocarray(void* ptr, size_t count, size_t size);
+
+extern void* RPMALLOC_CDECL
 reallocarray(void* ptr, size_t count, size_t size) {
 	size_t total;
 #if ENABLE_VALIDATE_ARGS

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -3545,6 +3545,11 @@ rpmalloc_heap_free_all(rpmalloc_heap_t* heap) {
 			_rpmalloc_heap_cache_insert(heap, span);
 			span = next_span;
 		}
+
+		span = heap->size_class[iclass].cache;
+		if (span)
+			_rpmalloc_heap_cache_insert(heap, span);
+		heap->size_class[iclass].cache = 0;
 	}
 	memset(heap->size_class, 0, sizeof(heap->size_class));
 	memset(heap->full_span, 0, sizeof(heap->full_span));


### PR DESCRIPTION
Fixes #318 - properly release the span cache in first class heap free all. Introduce a test case to cover this. Also fixes a compilation issue with nonstandard override on macos.