### PR TITLE
perf: check global cache before extracting from reserved memory

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -1858,15 +1858,15 @@ _rpmalloc_heap_extract_new_span(heap_t* heap, heap_size_class_t* heap_size_class
 			_rpmalloc_inc_span_statistics(heap, span_count, class_idx);
 			return span;
 		}
-		span = _rpmalloc_heap_reserved_extract(heap, span_count);
-		if (EXPECTED(span != 0)) {
-			_rpmalloc_stat_inc(&heap->size_class_use[class_idx].spans_from_reserved);
-			_rpmalloc_inc_span_statistics(heap, span_count, class_idx);
-			return span;
-		}
 		span = _rpmalloc_heap_global_cache_extract(heap, span_count);
 		if (EXPECTED(span != 0)) {
 			_rpmalloc_stat_inc(&heap->size_class_use[class_idx].spans_from_cache);
+			_rpmalloc_inc_span_statistics(heap, span_count, class_idx);
+			return span;
+		}
+		span = _rpmalloc_heap_reserved_extract(heap, span_count);
+		if (EXPECTED(span != 0)) {
+			_rpmalloc_stat_inc(&heap->size_class_use[class_idx].spans_from_reserved);
 			_rpmalloc_inc_span_statistics(heap, span_count, class_idx);
 			return span;
 		}


### PR DESCRIPTION
The allocator should check the global cache for an available span before extracting a span of memory from the reserved memory to avoid cache bloating. Besides, extracting from reserved memory eagerly may also increase the degree of memory fragmentation.