### PR TITLE
Add ARM64 support on Windows

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -841,7 +841,11 @@ rpmalloc_set_main_thread(void) {
 static void
 _rpmalloc_spin(void) {
 #if defined(_MSC_VER)
+#if defined(__x86_64__) || defined(__i386__)
 	_mm_pause();
+#else 
+	__yield();
+#endif
 #elif defined(__x86_64__) || defined(__i386__)
 	__asm__ volatile("pause" ::: "memory");
 #elif defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH >= 7)


### PR DESCRIPTION
I didn't do a thorough check but this seems to work for my use cases. It's a simple enough change where I just call the `__yield` intrinsic instead of `_mm_pause` which was leading to compilation problems.