### PR TITLE
fix: i686

### DIFF
--- a/rpmalloc/malloc.c
+++ b/rpmalloc/malloc.c
@@ -371,7 +371,11 @@ _global_rpmalloc_xib(void) {
 
 #pragma section(".CRT$XIB",read)
 __declspec(allocate(".CRT$XIB")) void (*_rpmalloc_module_init)(void) = _global_rpmalloc_xib;
-#pragma comment(linker, "/include:_rpmalloc_module_init")
+#if defined(_M_IX86) || defined(__i386__)
+#pragma comment(linker, "/include:" "__rpmalloc_module_init")
+#else
+#pragma comment(linker, "/include:" "_rpmalloc_module_init")
+#endif
 
 #endif
 


### PR DESCRIPTION
The fix was inspired by these references in [python](https://github.com/python/cpython/blob/1dc1521042d5e750b4a129ac8dd439edafed6783/Objects/mimalloc/init.c#L665) and LLVM ([call](https://github.com/llvm/llvm-project/blob/d0dcf06ab8723cc4358ad446354cce875dd89577/compiler-rt/lib/asan/asan_win.cpp#L407), [macro definition](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/sanitizer_common/sanitizer_win_defs.h#L72))