### PR TITLE
Avoid compiling call to GetLargePageMinimum when it's not available

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -2026,7 +2026,11 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 	if (global_config.enable_huge_pages) {
 #if PLATFORM_WINDOWS
 		HANDLE token = 0;
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM)
 		size_t large_page_minimum = GetLargePageMinimum();
+#else
+		size_t large_page_minimum = 2 * 1024 * 1024;
+#endif
 		if (large_page_minimum)
 			OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &token);
 		if (token) {


### PR DESCRIPTION
Only certain flavors of Windows support GetLargePageMinimum (specifically WINAPI_PARTITION_APP and WINAPI_PARTITION_SYSTEM a.k.a Application or OneCore family

For the others we can default to 2MB, as that is the typical minimum size according to the docs
