### PR TITLE
android: Enable `tls_model("local_dynamic")` for NDK-less builds on LLVM >= 17

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -749,7 +749,7 @@ static pthread_key_t _memory_thread_heap;
 #    define TLS_MODEL
 #    define _Thread_local __declspec(thread)
 #  elif defined(__ANDROID__)
-#    if __ANDROID_API__ >= 29 && (__clang_major__ >= 17 || __NDK_MAJOR__ >= 26)
+#    if __ANDROID_API__ >= 29 && ((defined(__clang__) && (__clang_major__ >= 17)) || (defined(__NDK_MAJOR__) && (__NDK_MAJOR__ >= 26)))
 #      define TLS_MODEL __attribute__((tls_model("local-dynamic")))
 #    else
 #      define TLS_MODEL

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -749,7 +749,7 @@ static pthread_key_t _memory_thread_heap;
 #    define TLS_MODEL
 #    define _Thread_local __declspec(thread)
 #  elif defined(__ANDROID__)
-#    if __ANDROID_API__ >= 29 && defined(__NDK_MAJOR__) && __NDK_MAJOR__ >= 26
+#    if __ANDROID_API__ >= 29 && (__clang_major__ >= 17 || __NDK_MAJOR__ >= 26)
 #      define TLS_MODEL __attribute__((tls_model("local-dynamic")))
 #    else
 #      define TLS_MODEL


### PR DESCRIPTION
PR #347 fixed/removed using the `"initial-exec"` TLS model for Android which is no longer compatible since LLVM 17 where ELF TLS is enabled by default for API level 29.

It opted to instead enable `"local-dynamic"`, but only if the minimum API level is 29 _and_ the NDK is version 26 or higher, and otherwise doesn't define a TLS model at all.  However, this did not consider simple build cases where e.g. `clang --target aarch64-linux-android29` may be invoked without ever including an NDK header that sets `__NDK_MAJOR__ 26` or higher (noting that LLVM 17 is used since r26): https://togithub.com/mjansson/rpmalloc/pull/347#discussion_r1912096361

Instead, check if the `__clang_major__` define is `17` or higher, but also keep the original comparison in place just in case even if it's superfluous.  Also remove unnecessary `defined(XXX)` checks, since the C specification clarifies that undefined tokens are replaced with `0` which aptly turn the `>=` into `false`.
