### PR TITLE
fix: use shlex than pipes to support python3.13

### DIFF
--- a/build/ninja/generator.py
+++ b/build/ninja/generator.py
@@ -4,7 +4,7 @@
 
 import argparse
 import os
-import pipes
+import shlex
 import sys
 
 import platform
@@ -82,7 +82,7 @@ class Generator(object):
     env_keys = set(['CC', 'AR', 'LINK', 'CFLAGS', 'ARFLAGS', 'LINKFLAGS'])
     configure_env = dict((key, os.environ[key]) for key in os.environ if key in env_keys)
     if configure_env:
-      config_str = ' '.join([key + '=' + pipes.quote(configure_env[key]) for key in configure_env])
+      config_str = ' '.join([key + '=' + shlex.quote(configure_env[key]) for key in configure_env])
       self.writer.variable('configure_env', config_str + '$ ')
 
     if variables is None:


### PR DESCRIPTION
pipes is [removed](https://docs.python.org/zh-cn/3/library/pipes.html) in python 3.13, thus we use `shlex.quote` to replace `pipes.quote`, which are [the same](https://docs.python.org/zh-cn/2.7/library/pipes.html).