### PR TITLE
micro-optimize: Dispatch tiny size class refills directly with the already computed size class

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -427,7 +427,9 @@ struct page_t {
 struct span_t {
 	//! Page header
 	page_t page;
-	//! Owning heap
+	//! Owning heap (do not deduplicate into page.heap - that field is the
+	//! owner of page 0 as a memory page and changes if the page is adopted
+	//! by another heap, while the span owner must remain stable)
 	heap_t* heap;
 	//! Page address mask
 	uintptr_t page_address_mask;
@@ -1217,13 +1219,13 @@ page_allocate_block(page_t* page, unsigned int zero) {
 
 	// The page might be full when free list has been pushed to heap local free list,
 	// check if there is a thread free list to adopt
-	if (page->block_used == page->block_count)
-		page_adopt_thread_free_block_list(page);
-
 	if (page->block_used == page->block_count) {
-		// Page is now fully utilized
-		rpmalloc_assert(!page->is_full, "Page block use counter out of sync with full flag");
-		page_available_to_full(page);
+		page_adopt_thread_free_block_list(page);
+		if (page->block_used == page->block_count) {
+			// Page is now fully utilized
+			rpmalloc_assert(!page->is_full, "Page block use counter out of sync with full flag");
+			page_available_to_full(page);
+		}
 	}
 
 	if (zero) {
@@ -1753,6 +1755,12 @@ heap_allocate_block(heap_t* heap, size_t size, unsigned int zero) {
 #endif
 			return block;
 		}
+#if RPMALLOC_HEAP_STATISTICS
+		heap->stats.allocated_size += global_size_class[size_class].block_size;
+#endif
+		// The size class is already known - refill directly, skipping the
+		// generic path size class recomputation and dead local free list pop
+		return heap_allocate_block_small_to_large(heap, size_class, zero);
 	}
 	return heap_allocate_block_generic(heap, size, zero);
 }


### PR DESCRIPTION
When the tiny-size (≤1024B) allocation fast path misses its heap-level free list, it falls into `heap_allocate_block_generic`, which recomputes the size class from the raw size and re-pops the heap free list that is guaranteed empty (~11 wasted instructions plus an extra call layer on every refill).

Under bouncing free patterns this path executes tens of millions of times (24M refills per 100M malloc/free pairs in mimalloc-bench alloc-test1). Disassembly of the release build confirms the fast path now tail-jumps to the refill with the class already in a register.

The tiny fast-path miss calls `heap_allocate_block_small_to_large(heap, size_class, zero)` directly with the already-computed class. The duplicate `block_used == block_count` check in the refill is nested (adoption only decreases the count, so the second check is only reachable when the first passed).

full mimalloc-bench allt suite, 5 runs, branch (rp) and develop (rpdev) interleaved in each run; avg [min..max]:
```
  ┌──────────────────┬──────────────────────┬──────────────────────┬──────────────────┐
  │    benchmark     │     this branch      │       develop        │      delta       │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ redis (s)        │ 2.219 [2.14..2.34]   │ 2.352 [2.20..2.54]   │ −5.7%            │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ glibc-thread (s) │ 0.777 [0.771..0.786] │ 0.810 [0.800..0.819] │ −4.1%            │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ glibc-simple (s) │ 1.104 [1.09..1.13]   │ 1.146 [1.14..1.16]   │ −3.7%            │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ lua (s)          │ 0.746 [0.72..0.80]   │ 0.766 [0.73..0.80]   │ −2.6%            │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ alloc-test1 (s)  │ 2.886 [2.84..2.92]   │ 2.932 [2.89..2.96]   │ −1.6%            │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ larson (s)       │ 1.964 [1.95..1.99]   │ 1.994 [1.97..2.02]   │ −1.5%            │
  ├──────────────────┼──────────────────────┼──────────────────────┼──────────────────┤
  │ all others       │ —                    │ —                    │ within run noise │
  └──────────────────┴──────────────────────┴──────────────────────┴──────────────────┘
```
  RSS flat on every benchmark