### PR TITLE
Improve standard entry point overrides for LD_PRELOAD

### DIFF
--- a/rpmalloc/malloc.c
+++ b/rpmalloc/malloc.c
@@ -70,6 +70,8 @@ static void* rpaligned_alloc_reverse_nothrow(size_t size, size_t align, rp_nothr
 static void rpfree_size(void* p, size_t size) { (void)sizeof(size); rpfree(p); }
 static void rpfree_aligned(void* p, size_t align) { (void)sizeof(align); rpfree(p); }
 static void rpfree_size_aligned(void* p, size_t size, size_t align) { (void)sizeof(size); (void)sizeof(align); rpfree(p); }
+static void rpfree_nothrow(void* p, rp_nothrow_t t) { (void)sizeof(t); rpfree(p); }
+static void rpfree_aligned_nothrow(void* p, size_t align, rp_nothrow_t t) { (void)sizeof(align); (void)sizeof(t); rpfree(p); }
 
 #endif
 
@@ -113,6 +115,48 @@ rpreallocarray(void* ptr, size_t count, size_t size) {
 	return rprealloc(ptr, total);
 }
 
+extern inline size_t RPMALLOC_CDECL
+rpmalloc_good_size(size_t size) {
+	uint32_t size_class = get_size_class(size);
+	if (size_class < SIZE_CLASS_COUNT)
+		return global_size_class[size_class].block_size;
+	return get_page_aligned_size(size + SPAN_HEADER_SIZE) - SPAN_HEADER_SIZE;
+}
+
+extern inline int RPMALLOC_CDECL
+rpreallocarr(void* ptrp, size_t count, size_t size) {
+	if (!ptrp || !size) {
+		errno = EINVAL;
+		return EINVAL;
+	}
+	size_t total;
+#if defined(__GNUC__) || defined(__clang__)
+	if (__builtin_umull_overflow(count, size, &total)) {
+		errno = EOVERFLOW;
+		return EOVERFLOW;
+	}
+#else
+	total = count * size;
+	if ((total / size) != count) {
+		errno = EOVERFLOW;
+		return EOVERFLOW;
+	}
+#endif
+	void** op = (void**)ptrp;
+	if (total == 0) {
+		rpfree(*op);
+		*op = 0;
+		return 0;
+	}
+	void* newp = rprealloc(*op, total);
+	if (!newp) {
+		errno = ENOMEM;
+		return ENOMEM;
+	}
+	*op = newp;
+	return 0;
+}
+
 #if USE_IMPLEMENT
 
 extern inline void* RPMALLOC_CDECL malloc(size_t size) { return rpmalloc(size); }
@@ -129,6 +173,12 @@ extern inline size_t RPMALLOC_CDECL malloc_size(void* ptr) { return rpmalloc_usa
 extern inline void* RPMALLOC_CDECL valloc(size_t size) { return rpvalloc(size); }
 extern inline void* RPMALLOC_CDECL pvalloc(size_t size) { return rppvalloc(size); }
 extern inline void* RPMALLOC_CDECL reallocarray(void* ptr, size_t count, size_t size) { return rpreallocarray(ptr, count, size); }
+extern inline int RPMALLOC_CDECL reallocarr(void* ptr, size_t count, size_t size) { return rpreallocarr(ptr, count, size); }
+extern inline size_t RPMALLOC_CDECL malloc_good_size(size_t size) { return rpmalloc_good_size(size); }
+extern inline void RPMALLOC_CDECL vfree(void* ptr) { rpfree(ptr); }
+#ifndef _WIN32
+extern inline void* RPMALLOC_CDECL _aligned_malloc(size_t size, size_t alignment) { return rpaligned_alloc(alignment, size); }
+#endif
 
 #ifdef _WIN32
 extern inline void* RPMALLOC_CDECL _malloc_base(size_t size) { return rpmalloc(size); }
@@ -147,6 +197,10 @@ extern inline void* RPMALLOC_CDECL _realloc_base(void* ptr, size_t size) { retur
 #define RPDEFVIS __attribute__((visibility("default")))
 extern void _ZdlPv(void* p); void RPDEFVIS _ZdlPv(void* p) { rpfree(p); }
 extern void _ZdaPv(void* p); void RPDEFVIS _ZdaPv(void* p) { rpfree(p); }
+extern void _ZdlPvRKSt9nothrow_t(void* p, rp_nothrow_t t); void RPDEFVIS _ZdlPvRKSt9nothrow_t(void* p, rp_nothrow_t t) { (void)sizeof(t); rpfree(p); }
+extern void _ZdaPvRKSt9nothrow_t(void* p, rp_nothrow_t t); void RPDEFVIS _ZdaPvRKSt9nothrow_t(void* p, rp_nothrow_t t) { (void)sizeof(t); rpfree(p); }
+extern void _ZdlPvSt11align_val_tRKSt9nothrow_t(void* p, size_t align, rp_nothrow_t t); void RPDEFVIS _ZdlPvSt11align_val_tRKSt9nothrow_t(void* p, size_t align, rp_nothrow_t t) { (void)sizeof(align); (void)sizeof(t); rpfree(p); }
+extern void _ZdaPvSt11align_val_tRKSt9nothrow_t(void* p, size_t align, rp_nothrow_t t); void RPDEFVIS _ZdaPvSt11align_val_tRKSt9nothrow_t(void* p, size_t align, rp_nothrow_t t) { (void)sizeof(align); (void)sizeof(t); rpfree(p); }
 #if ARCH_64BIT
 // 64-bit operators new and new[], normal and aligned
 extern void* _Znwm(uint64_t size); void* RPDEFVIS _Znwm(uint64_t size) { return rpmalloc(size); }
@@ -242,6 +296,11 @@ __attribute__ ((section("__DATA, __interpose"))) = {
 void _ZdlPv(void* p) RPALIAS(rpfree)
 void _ZdaPv(void* p) RPALIAS(rpfree)
 
+void _ZdlPvRKSt9nothrow_t(void* p, rp_nothrow_t t) RPALIAS(rpfree_nothrow)
+void _ZdaPvRKSt9nothrow_t(void* p, rp_nothrow_t t) RPALIAS(rpfree_nothrow)
+void _ZdlPvSt11align_val_tRKSt9nothrow_t(void* p, size_t a, rp_nothrow_t t) RPALIAS(rpfree_aligned_nothrow)
+void _ZdaPvSt11align_val_tRKSt9nothrow_t(void* p, size_t a, rp_nothrow_t t) RPALIAS(rpfree_aligned_nothrow)
+
 #if ARCH_64BIT
 // 64-bit operators new and new[], normal and aligned
 void* _Znwm(uint64_t size) RPALIAS(rpmalloc)
@@ -300,11 +359,17 @@ size_t malloc_usable_size(const void* ptr) RPALIAS(rpmalloc_usable_size)
 size_t malloc_usable_size(void* ptr) RPALIAS(rpmalloc_usable_size)
 #endif
 size_t malloc_size(void* ptr) RPALIAS(rpmalloc_usable_size)
+size_t malloc_good_size(size_t size) RPALIAS(rpmalloc_good_size)
+void vfree(void* ptr) RPALIAS(rpfree)
+void* _aligned_malloc(size_t size, size_t alignment) RPALIAS(rpaligned_alloc_reverse)
+__attribute__((weak, visibility("default")))
+int reallocarr(void* ptr, size_t count, size_t size);
+int reallocarr(void* ptr, size_t count, size_t size) { return rpreallocarr(ptr, count, size); }
 
 // end USE_ALIAS
 #endif
 
-#if defined(__GLIBC__) && defined(__linux__) && 0
+#if defined(__GLIBC__) && defined(__linux__)
 
 void* __libc_malloc(size_t size) RPALIAS(rpmalloc)
 void* __libc_calloc(size_t count, size_t size) RPALIAS(rpcalloc)


### PR DESCRIPTION
Enable the __libc_malloc/calloc/realloc/free/cfree/valloc/pvalloc/memalign and __posix_memalign overrides on glibc Linux (previously compiled out with an '&& 0' guard). glibc routes many internal allocations through __libc_malloc rather than the interposable malloc symbol. Without overriding these, such allocations escape to glibc's allocator and a later free through the interposed rpfree (which has no foreign-pointer guard) corrupts or crashes.

Add the nothrow operator delete and delete[] variants, normal and aligned (_ZdlPvRKSt9nothrow_t, _ZdaPvRKSt9nothrow_t, _ZdlPvSt11align_val_tRKSt9nothrow_t, _ZdaPvSt11align_val_tRKSt9nothrow_t), which were missing while the matching nothrow new operators were already present.

Add some portability entry points also overrides: reallocarr (NetBSD, weak so a system definition wins), malloc_good_size and vfree (BSD/macOS), and a _aligned_malloc alias.
