### PR TITLE
Pack multiple heaps per mapping and reuse pristine heaps

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -172,6 +172,12 @@ madvise(caddr_t, size_t, int);
 #define PAGE_HEADER_SIZE 128
 #define SPAN_HEADER_SIZE PAGE_HEADER_SIZE
 
+//! Alignment of each heap control structure within a shared mapping. Keeps adjacent
+//  heaps on separate cache lines so cross-thread writes to one heap (thread_free) do
+//  not falsely share with a neighbour heap owned by another thread. Sized for a 128 byte
+//  cache line (Apple Silicon, x86 destructive interference) to cover 64 byte lines too.
+#define HEAP_ALIGNMENT 128
+
 #define SMALL_GRANULARITY 16
 
 #define SMALL_BLOCK_SIZE_LIMIT (4 * 1024)
@@ -534,10 +540,19 @@ _Static_assert(sizeof(heap_t) <= 4096, "Invalid heap size");
 static RPMALLOC_CACHE_ALIGNED heap_t global_heap_fallback;
 //! Default heap
 static heap_t* global_heap_default = &global_heap_fallback;
-//! Available heaps
+//! Released heaps available for reuse. These have been used and may hold caches, so they are
+//  only handed to ordinary thread heaps, never to first-class heaps (which require pristine state)
 static heap_t* global_heap_queue;
+//! Pristine, never-used heaps carved from a shared block but not yet handed out. Safe for any
+//  request including first-class, which needs a heap with no prior allocations
+static heap_t* global_heap_pristine;
 //! In use heaps
 static heap_t* global_heap_used;
+//! Set while a thread is mapping and carving a new shared heap block, so concurrent thread
+//  starts wait for the carved heaps to reach a pool instead of each mapping their own block.
+//  A user memory interface callback must not allocate through rpmalloc on the creating thread:
+//  a nested heap creation would wait on this flag set by the same thread and deadlock
+static int global_heap_creating;
 //! Lock for heap queue
 static atomic_uintptr_t global_heap_lock;
 //! Heap ID counter
@@ -1723,29 +1738,104 @@ heap_initialize(void* block) {
 	return heap;
 }
 
+// A heap control structure is much smaller than the mapping page size (and far smaller than a
+// huge page), so a single page-aligned mapping is carved into as many heaps as fit, the first
+// returned to the caller and the extras queued for reuse. This avoids mapping (and, under huge
+// pages, committing) a whole page per heap. Only the first heap records the mapping offset and
+// size; it owns the shared mapping and is the one heap that unmaps it at finalize.
+//
+// Block creation is serialized through global_heap_creating: when no heap is available, one thread
+// maps and carves a block while concurrent thread starts wait for the carved heaps to be published,
+// so a startup burst maps a single block instead of one block per thread. Ordinary requests reuse a
+// released heap first, then a pristine carved one. First-class requests need a heap with no prior
+// allocations, so they take only pristine heaps (a carved extra, or a freshly mapped master), never
+// a released one, but still wait so they do not map concurrently with another creation.
 static heap_t*
-heap_allocate_new(void) {
+heap_allocate_new(int first_class) {
 	if (!global_config.page_size)
 		rpmalloc_initialize(0);
-	size_t heap_size = get_page_aligned_size(sizeof(heap_t));
+
+	heap_lock_acquire();
+	while (1) {
+		if (!first_class && global_heap_queue) {
+			heap_t* heap = global_heap_queue;
+			global_heap_queue = heap->next;
+			heap_lock_release();
+			return heap;
+		}
+		if (global_heap_pristine) {
+			heap_t* heap = global_heap_pristine;
+			global_heap_pristine = heap->next;
+			heap_lock_release();
+			return heap;
+		}
+		if (!global_heap_creating)
+			break;
+		heap_lock_release();
+		wait_spin();
+		heap_lock_acquire();
+	}
+	global_heap_creating = 1;
+	heap_lock_release();
+
+	size_t aligned_heap_size = HEAP_ALIGNMENT * ((sizeof(heap_t) + (HEAP_ALIGNMENT - 1)) / HEAP_ALIGNMENT);
+	size_t block_size = get_page_aligned_size(aligned_heap_size);
 	size_t offset = 0;
 	size_t mapped_size = 0;
-	block_t* block = global_memory_interface->memory_map(heap_size, 0, &offset, &mapped_size);
+	block_t* block = global_memory_interface->memory_map(block_size, 0, &offset, &mapped_size);
 #if ENABLE_DECOMMIT
-	if (os_commit_on_demand() && (global_memory_interface->memory_commit(block, heap_size) != 0)) {
+	if (block && os_commit_on_demand() && (global_memory_interface->memory_commit(block, block_size) != 0)) {
 		global_memory_interface->memory_unmap(block, offset, mapped_size);
-		return 0;
+		block = 0;
 	}
 #endif
+	if (!block) {
+		heap_lock_acquire();
+		global_heap_creating = 0;
+		heap_lock_release();
+		return 0;
+	}
+
 	heap_t* heap = heap_initialize((void*)block);
 	heap->offset = (uint32_t)offset;
 	heap->mapped_size = mapped_size;
+
+	// Carve the remaining heaps into a local chain, then splice it onto the pristine pool in one
+	// step so the lock is not held across the per-heap initialization. heap_initialize zeroes each
+	// structure, leaving mapped_size == 0 so the extras are not treated as mapping owners. They are
+	// pristine until handed out, so first-class requests may reuse them.
+	size_t heap_count = mapped_size / aligned_heap_size;
+	heap_t* chain_head = 0;
+	heap_t* chain_tail = 0;
+	heap_t* extra_heap = (heap_t*)pointer_offset(heap, aligned_heap_size);
+	for (size_t iheap = 1; iheap < heap_count; ++iheap) {
+		heap_initialize((void*)extra_heap);
+		if (!chain_tail)
+			chain_tail = extra_heap;
+		extra_heap->next = chain_head;
+		chain_head = extra_heap;
+		extra_heap = (heap_t*)pointer_offset(extra_heap, aligned_heap_size);
+	}
+
+	heap_lock_acquire();
+	if (chain_tail) {
+		chain_tail->next = global_heap_pristine;
+		global_heap_pristine = chain_head;
+	}
+	global_heap_creating = 0;
+	heap_lock_release();
 #if ENABLE_STATISTICS
-	atomic_fetch_add_explicit(&global_statistics.heap_count, 1, memory_order_relaxed);
+	atomic_fetch_add_explicit(&global_statistics.heap_count, heap_count, memory_order_relaxed);
 #endif
 	return heap;
 }
 
+// Unmaps the shared block owned by this heap. INVARIANT: heap blocks are only ever unmapped here,
+// at global finalize, never while the allocator is running. Several heaps share a block, and a heap
+// may be borrowed by an unrelated owner's thread or by a first-class heap that outlives the thread
+// whose request mapped the block (see heap_allocate_new). Unmapping a block mid-run would leave
+// those borrowed heaps pointing at freed memory, so any future block reclamation must guarantee no
+// heap carved from the block is still live.
 static void
 heap_unmap(heap_t* heap) {
 	global_memory_interface->memory_unmap(heap, heap->offset, heap->mapped_size);
@@ -1753,15 +1843,7 @@ heap_unmap(heap_t* heap) {
 
 static heap_t*
 heap_allocate(int first_class) {
-	heap_t* heap = 0;
-	if (!first_class) {
-		heap_lock_acquire();
-		heap = global_heap_queue;
-		global_heap_queue = heap ? heap->next : 0;
-		heap_lock_release();
-	}
-	if (!heap)
-		heap = heap_allocate_new();
+	heap_t* heap = heap_allocate_new(first_class);
 	if (heap) {
 		uintptr_t current_thread_id = get_thread_id();
 		heap_lock_acquire();
@@ -2645,12 +2727,30 @@ rpmalloc_finalize(void) {
 #endif
 
 	if (global_config.unmap_on_finalize) {
-		heap_t* heap = global_heap_queue;
+		// Heaps can share a mapping (heap_allocate_new); only the owner carries mapped_size != 0.
+		// Resources are freed while every heap is still mapped, then owners are unmapped in a
+		// separate pass so a heap is never dereferenced after its shared mapping is gone.
+		heap_t* owners = 0;
+		heap_t* heap = global_heap_pristine;
+		global_heap_pristine = 0;
+		while (heap) {
+			heap_t* heap_next = heap->next;
+			heap_free_all(heap);
+			if (heap->mapped_size) {
+				heap->next = owners;
+				owners = heap;
+			}
+			heap = heap_next;
+		}
+		heap = global_heap_queue;
 		global_heap_queue = 0;
 		while (heap) {
 			heap_t* heap_next = heap->next;
 			heap_free_all(heap);
-			heap_unmap(heap);
+			if (heap->mapped_size) {
+				heap->next = owners;
+				owners = heap;
+			}
 			heap = heap_next;
 		}
 		heap = global_heap_used;
@@ -2658,8 +2758,16 @@ rpmalloc_finalize(void) {
 		while (heap) {
 			heap_t* heap_next = heap->next;
 			heap_free_all(heap);
-			heap_unmap(heap);
+			if (heap->mapped_size) {
+				heap->next = owners;
+				owners = heap;
+			}
 			heap = heap_next;
+		}
+		while (owners) {
+			heap_t* owner_next = owners->next;
+			heap_unmap(owners);
+			owners = owner_next;
 		}
 #if ENABLE_STATISTICS
 		memset(&global_statistics, 0, sizeof(global_statistics));
@@ -2674,6 +2782,7 @@ rpmalloc_finalize(void) {
 	pthread_key = 0;
 #endif
 
+	global_heap_creating = 0;
 	global_main_thread_id = 0;
 	global_rpmalloc_initialized = 0;
 }
@@ -2744,10 +2853,10 @@ rpmalloc_global_statistics(rpmalloc_global_statistics_t* stats) {
 
 rpmalloc_heap_t*
 rpmalloc_heap_acquire(void) {
-	// Must be a pristine heap from newly mapped memory pages, or else memory blocks
-	// could already be allocated from the heap which would (wrongly) be released when
-	// heap is cleared with rpmalloc_heap_free_all(). Also heaps guaranteed to be
-	// pristine from the dedicated orphan list can be used.
+	// Must be a pristine heap, or else memory blocks could already be allocated from the heap
+	// which would (wrongly) be released when heap is cleared with rpmalloc_heap_free_all().
+	// heap_allocate(1) returns either a never-used heap carved from a shared block (whether that
+	// block was mapped for an ordinary heap or a prior first-class heap) or a freshly mapped one.
 	heap_t* heap = heap_allocate(1);
 	rpmalloc_assume(heap != 0);
 	heap->owner_thread = 0;

--- a/test/main.c
+++ b/test/main.c
@@ -36,6 +36,10 @@
 #include <unistd.h>
 #endif
 
+#if !defined(_WIN32)
+#include <sys/mman.h>
+#endif
+
 #define pointer_offset(ptr, ofs) (void*)((char*)(ptr) + (ptrdiff_t)(ofs))
 #define pointer_diff(first, second) (ptrdiff_t)((const char*)(first) - (const char*)(second))
 
@@ -1055,6 +1059,7 @@ test_first_class_heaps(void) {
 	unsigned int i;
 	size_t num_alloc_threads;
 	allocator_thread_arg_t arg[32];
+	thread_arg targ[32];
 
 	rpmalloc_config_t config = {0};
 	//config.unmap_on_finalize = 1;
@@ -1093,13 +1098,14 @@ test_first_class_heaps(void) {
 #endif
 		arg[i].init_fini_each_loop = 1;
 
-		thread_arg targ;
-		targ.fn = heap_allocator_thread;
+		// targ must outlive the thread, which reads it asynchronously until join below, so it
+		// cannot be a per-iteration stack local
+		targ[i].fn = heap_allocator_thread;
 		if ((i % 2) != 0)
-			targ.fn = allocator_thread;
-		targ.arg = &arg[i];
+			targ[i].fn = allocator_thread;
+		targ[i].arg = &arg[i];
 
-		thread[i] = thread_run(&targ);
+		thread[i] = thread_run(&targ[i]);
 	}
 
 	thread_sleep(1000);
@@ -1269,6 +1275,197 @@ test_named_pages(void) {
 	return 0;
 }
 
+static int
+test_finalize_unmap(void) {
+	// Exercises heap packing together with unmap_on_finalize, which the other tests leave disabled
+	// (they let the OS reclaim memory at exit). Threads repeatedly create and destroy heaps, drawing
+	// from the pristine and reuse pools, and first-class heaps draw pristine heaps from the same
+	// shared blocks. rpmalloc_finalize then unmaps every shared block exactly once via its owner.
+	// Runs with the default page size and with a forced larger page size so many heaps are carved
+	// per block.
+	size_t page_size[2];
+	page_size[0] = 0;
+	page_size[1] = 256 * 1024;
+
+	for (unsigned int icfg = 0; icfg < 2; ++icfg) {
+		rpmalloc_config_t config = {0};
+		config.page_size = page_size[icfg];
+		config.unmap_on_finalize = 1;
+		rpmalloc_initialize_config(0, &config);
+
+		allocator_thread_arg_t arg = {0};
+		arg.loops = 30;
+		arg.passes = 8;
+		arg.datasize[0] = 19;
+		arg.datasize[1] = 249;
+		arg.datasize[2] = 797;
+		arg.datasize[3] = 3;
+		arg.datasize[4] = 7949;
+		arg.datasize[5] = 34;
+		arg.datasize[6] = 389;
+		arg.num_datasize = 7;
+
+		size_t num_threads = hardware_threads;
+		if (num_threads < 2)
+			num_threads = 2;
+		if (num_threads > 16)
+			num_threads = 16;
+
+		thread_arg targ;
+		targ.fn = initfini_thread;
+		targ.arg = &arg;
+
+		uintptr_t thread[16];
+		for (size_t i = 0; i < num_threads; ++i)
+			thread[i] = thread_run(&targ);
+
+#if RPMALLOC_FIRST_CLASS_HEAPS
+		// First-class heaps must come back pristine; here they reuse never-used heaps carved from
+		// the shared blocks (mapped for the worker heaps or for earlier first-class heaps).
+		rpmalloc_heap_t* heap[64];
+		for (unsigned int i = 0; i < 64; ++i) {
+			heap[i] = rpmalloc_heap_acquire();
+			void* p = rpmalloc_heap_alloc(heap[i], 1000 + i * 137);
+			if (!p)
+				return test_fail("First class allocation failed in finalize unmap test");
+			rpmalloc_heap_free(heap[i], p);
+		}
+		for (unsigned int i = 0; i < 64; ++i)
+			rpmalloc_heap_release(heap[i]);
+#endif
+
+		int failed = 0;
+		for (size_t i = 0; i < num_threads; ++i) {
+			if (thread_join(thread[i]) != 0)
+				failed = 1;
+		}
+
+		rpmalloc_finalize();
+
+		if (failed)
+			return test_fail("Thread failed in finalize unmap test");
+	}
+
+	printf("Finalize unmap (heap packing) tests passed\n");
+	return 0;
+}
+
+#if !defined(_WIN32) && RPMALLOC_FIRST_CLASS_HEAPS
+
+// Counting memory interface used by test_heap_packing. Heap control blocks are the only mappings
+// requested with alignment 0 (spans and huge blocks use span-size alignment), so counting those
+// maps tells us exactly how many heap blocks were mapped. The test drives this single-threaded, so
+// a plain counter is sufficient.
+static size_t test_pack_block_maps;
+
+static void*
+test_pack_map(size_t size, size_t alignment, size_t* offset, size_t* mapped_size) {
+	size_t map_size = size + alignment;
+	void* ptr = mmap(0, map_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+	if (ptr == MAP_FAILED)
+		return 0;
+	*offset = 0;
+	if (alignment) {
+		uintptr_t unalign = (uintptr_t)ptr & (uintptr_t)(alignment - 1);
+		size_t padding = unalign ? (alignment - unalign) : 0;
+		if (padding)
+			munmap(ptr, padding);
+		ptr = pointer_offset(ptr, padding);
+		if (alignment - padding)
+			munmap(pointer_offset(ptr, size), alignment - padding);
+		map_size = size;
+	} else {
+		++test_pack_block_maps;
+	}
+	*mapped_size = map_size;
+	return ptr;
+}
+
+static void
+test_pack_unmap(void* address, size_t offset, size_t mapped_size) {
+	munmap(pointer_offset(address, -(ptrdiff_t)offset), mapped_size);
+}
+
+static int
+test_pack_commit(void* address, size_t size) {
+	(void)address;
+	(void)size;
+	return 0;
+}
+
+static int
+test_pack_decommit(void* address, size_t size) {
+	(void)address;
+	(void)size;
+	return 0;
+}
+
+#endif
+
+static int
+test_heap_packing(void) {
+	// Regression guard for the heap packing guarantees: many heaps are carved from a single mapped
+	// block, and first-class heaps reuse the pristine carved heaps instead of mapping a fresh block
+	// each time. Driven single-threaded through a counting memory interface so it is deterministic.
+#if defined(_WIN32) || !RPMALLOC_FIRST_CLASS_HEAPS
+	printf("Heap packing test skipped\n");
+	return 0;
+#else
+	rpmalloc_interface_t iface = {0};
+	iface.memory_map = test_pack_map;
+	iface.memory_unmap = test_pack_unmap;
+	iface.memory_commit = test_pack_commit;
+	iface.memory_decommit = test_pack_decommit;
+
+	rpmalloc_config_t config = {0};
+	config.page_size = 256 * 1024;  // large page so many heaps pack into one block
+	config.unmap_on_finalize = 1;
+
+	test_pack_block_maps = 0;
+	rpmalloc_initialize_config(&iface, &config);
+
+	// Initializing the main thread heap maps one block and carves its pristine extras from it
+	if (test_pack_block_maps < 1)
+		return test_fail("No heap block was mapped at initialize");
+
+	// Acquire first-class heaps one at a time. They must draw pristine carved heaps from the existing
+	// block with no new mapping until the block's pristine heaps run out, at which point exactly one
+	// new block is mapped. No acquire may map more than one block.
+	rpmalloc_heap_t* heap[1024];
+	unsigned int reused_before_remap = 0;
+	unsigned int acquired = 0;
+	while (acquired < 1024) {
+		size_t before = test_pack_block_maps;
+		heap[acquired] = rpmalloc_heap_acquire();
+		if (!heap[acquired])
+			return test_fail("First class heap acquire failed");
+		size_t after = test_pack_block_maps;
+		++acquired;
+		if (after == before) {
+			++reused_before_remap;
+		} else if (after == before + 1) {
+			break;  // pristine pool drained, one new block mapped
+		} else {
+			return test_fail("More than one heap block mapped for a single acquire");
+		}
+	}
+
+	// Packing and first-class reuse: those acquires were served from the existing block with no new
+	// mapping (the loop above errors out otherwise). With a 256KiB page and a heap control block of
+	// at most 4KiB a block holds at least 64 heaps; require a comfortably lower bound so the test is
+	// robust to heap_t size changes.
+	if (reused_before_remap < 16)
+		return test_fail("Heap block packed too few heaps, or first class did not reuse pristine heaps");
+
+	for (unsigned int i = 0; i < acquired; ++i)
+		rpmalloc_heap_release(heap[i]);
+	rpmalloc_finalize();
+
+	printf("Heap packing tests passed (%u first class heaps reused from one block)\n", reused_before_remap);
+	return 0;
+#endif
+}
+
 extern int
 test_malloc(int print_log);
 
@@ -1310,6 +1507,10 @@ test_run(int argc, char** argv) {
 	if (test_first_class_heaps())
 		return -1;
 	if (test_named_pages())
+		return -1;
+	if (test_finalize_unmap())
+		return -1;
+	if (test_heap_packing())
 		return -1;
 	printf("All tests passed\n");
 	return 0;


### PR DESCRIPTION
Carve many heaps from one mapping instead of a whole page (or huge page) per heap; serialize block creation so a thread-start burst maps one shared block. Split released vs never-used heaps so first-class heaps reuse pristine carved heaps instead of mapping a fresh block each acquire. Finalize unmaps each shared block once via its owner.

Add packing and finalize-unmap tests, and fix a pre-existing stack-use-after-scope in test_first_class_heaps.