### PR TITLE
Implement thread statistics and restore per heap stat counters

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -289,7 +289,47 @@ statistics_sub_saturating(atomic_size_t* counter, size_t value) {
 	    !atomic_compare_exchange_weak_explicit(counter, &current, next, memory_order_relaxed, memory_order_relaxed));
 }
 
+//! Per size class allocation counters, updated only by the owning thread (cross-thread frees are
+//  deferred and accounted when the owner processes them), so plain integers suffice
+typedef struct heap_size_use_t {
+	int32_t alloc_current;
+	int32_t alloc_peak;
+	int32_t alloc_total;
+	int32_t free_total;
+} heap_size_use_t;
+
+//! A successful allocation of the given size class on the owning heap
+#define _rpmalloc_stat_inc_alloc(heap, class_idx)                       \
+	do {                                                                \
+		heap_size_use_t* _su = (heap)->size_use + (class_idx);          \
+		if (++_su->alloc_current > _su->alloc_peak)                     \
+			_su->alloc_peak = _su->alloc_current;                       \
+		++_su->alloc_total;                                             \
+	} while (0)
+//! Account for a number of freed blocks of the given size class on the owning heap
+#define _rpmalloc_stat_add_free(heap, class_idx, count)                 \
+	do {                                                                \
+		heap_size_use_t* _su = (heap)->size_use + (class_idx);          \
+		_su->alloc_current -= (int32_t)(count);                         \
+		_su->free_total += (int32_t)(count);                            \
+	} while (0)
+//! A raw memory map call for a span of the given page type on the owning heap
+#define _rpmalloc_stat_inc_span_map(heap, page_type) \
+	do {                                             \
+		++(heap)->span_map_calls[page_type];         \
+	} while (0)
+
 #else
+
+#define _rpmalloc_stat_inc_alloc(heap, class_idx) \
+	do {                                          \
+	} while (0)
+#define _rpmalloc_stat_add_free(heap, class_idx, count) \
+	do {                                                \
+	} while (0)
+#define _rpmalloc_stat_inc_span_map(heap, page_type) \
+	do {                                             \
+	} while (0)
 
 #endif
 
@@ -523,6 +563,12 @@ struct heap_t {
 	size_t mapped_size;
 #if RPMALLOC_HEAP_STATISTICS
 	struct rpmalloc_heap_statistics_t stats;
+#endif
+#if ENABLE_STATISTICS
+	//! Per size class allocation counters (current span_use count is computed live on demand)
+	heap_size_use_t size_use[SIZE_CLASS_COUNT];
+	//! Per page type raw span map call counters
+	uint32_t span_map_calls[5];
 #endif
 };
 
@@ -1245,6 +1291,7 @@ page_put_local_free_block(page_t* page, block_t* block) {
 	block->next = page->local_free;
 	page->local_free = block;
 	++page->local_free_count;
+	_rpmalloc_stat_add_free(page->heap, page->size_class, 1);
 	if (UNEXPECTED(--page->block_used == 0)) {
 		page_available_to_free(page);
 	} else if (UNEXPECTED(page->is_full != 0)) {
@@ -1265,6 +1312,7 @@ page_adopt_thread_free_block_list(page_t* page) {
 		page->local_free_count = page_block_from_thread_free_list(page, thread_free, &page->local_free);
 		rpmalloc_assert(page->local_free_count <= page->block_used, "Page thread free list count internal failure");
 		page->block_used -= page->local_free_count;
+		_rpmalloc_stat_add_free(page->heap, page->size_class, page->local_free_count);
 	}
 }
 
@@ -1685,6 +1733,7 @@ block_deallocate(block_t* block) {
 			block->next = page->local_free;
 			page->local_free = block;
 			++page->local_free_count;
+			_rpmalloc_stat_add_free(page->heap, page->size_class, 1);
 			if (UNEXPECTED(--page->block_used == 0))
 				page_available_to_free(page);
 		} else {
@@ -1824,9 +1873,6 @@ heap_allocate_new(int first_class) {
 	}
 	global_heap_creating = 0;
 	heap_lock_release();
-#if ENABLE_STATISTICS
-	atomic_fetch_add_explicit(&global_statistics.heap_count, heap_count, memory_order_relaxed);
-#endif
 	return heap;
 }
 
@@ -1854,12 +1900,21 @@ heap_allocate(int first_class) {
 		global_heap_used = heap;
 		heap_lock_release();
 		heap->owner_thread = current_thread_id;
+#if ENABLE_STATISTICS
+		// Per-thread statistics start fresh for the new owner; a reused heap is not reinitialized
+		memset(heap->size_use, 0, sizeof(heap->size_use));
+		memset(heap->span_map_calls, 0, sizeof(heap->span_map_calls));
+		atomic_fetch_add_explicit(&global_statistics.heap_count, 1, memory_order_relaxed);
+#endif
 	}
 	return heap;
 }
 
 static inline void
 heap_release(heap_t* heap) {
+#if ENABLE_STATISTICS
+	statistics_sub_saturating(&global_statistics.heap_count, 1);
+#endif
 	heap_lock_acquire();
 	if (heap->prev)
 		heap->prev->next = heap->next;
@@ -1932,6 +1987,7 @@ heap_get_span(heap_t* heap, page_type_t page_type) {
 	heap->stats.mapped_size += mapped_size;
 #endif
 	if (EXPECTED(span != 0)) {
+		_rpmalloc_stat_inc_span_map(heap, page_type);
 		uint32_t page_count = 0;
 		uint32_t page_size = 0;
 		uintptr_t page_address_mask = 0;
@@ -2103,6 +2159,8 @@ heap_allocate_block_huge(heap_t* heap, size_t size, unsigned int zero) {
 		block = global_memory_interface->memory_map(alloc_size, SPAN_SIZE, &offset, &mapped_size);
 	if (block) {
 		span_t* span = block;
+		if (!from_cache)
+			_rpmalloc_stat_inc_span_map(heap, PAGE_HUGE);
 #if ENABLE_DECOMMIT
 		if (!from_cache && os_commit_on_demand() &&
 		    (global_memory_interface->memory_commit(span, alloc_size) != 0)) {
@@ -2169,6 +2227,7 @@ heap_allocate_block_generic(heap_t* heap, size_t size, unsigned int zero) {
 #if RPMALLOC_HEAP_STATISTICS
 		heap->stats.allocated_size += global_size_class[size_class].block_size;
 #endif
+		_rpmalloc_stat_inc_alloc(heap, size_class);
 
 		block_t* block = heap_pop_local_free(heap, size_class);
 		if (EXPECTED(block != 0)) {
@@ -2197,11 +2256,13 @@ heap_allocate_block(heap_t* heap, size_t size, unsigned int zero) {
 #if RPMALLOC_HEAP_STATISTICS
 			heap->stats.allocated_size += global_size_class[size_class].block_size;
 #endif
+			_rpmalloc_stat_inc_alloc(heap, size_class);
 			return block;
 		}
 #if RPMALLOC_HEAP_STATISTICS
 		heap->stats.allocated_size += global_size_class[size_class].block_size;
 #endif
+		_rpmalloc_stat_inc_alloc(heap, size_class);
 		// The size class is already known - refill directly, skipping the
 		// generic path size class recomputation and dead local free list pop
 		return heap_allocate_block_small_to_large(heap, size_class, zero);
@@ -2807,6 +2868,49 @@ rpmalloc_thread_collect(void) {
 }
 
 void
+rpmalloc_thread_statistics(rpmalloc_thread_statistics_t* stats) {
+	memset(stats, 0, sizeof(rpmalloc_thread_statistics_t));
+#if ENABLE_STATISTICS
+	heap_t* heap = get_thread_heap();
+	if (!heap || (heap->id == 0))
+		return;
+
+	// Size class cache: free blocks held at heap level and in partially used pages, computed live
+	for (uint32_t iclass = 0; iclass < SIZE_CLASS_COUNT; ++iclass) {
+		size_t block_size = global_size_class[iclass].block_size;
+		size_t free_count = 0;
+		for (block_t* block = heap->local_free[iclass]; block; block = block->next)
+			++free_count;
+		for (page_t* page = heap->page_available[iclass]; page; page = page->next)
+			free_count += page->local_free_count;
+		stats->sizecache += free_count * block_size;
+
+		stats->size_use[iclass].alloc_current = (size_t)heap->size_use[iclass].alloc_current;
+		stats->size_use[iclass].alloc_peak = (size_t)heap->size_use[iclass].alloc_peak;
+		stats->size_use[iclass].alloc_total = (size_t)heap->size_use[iclass].alloc_total;
+		stats->size_use[iclass].free_total = (size_t)heap->size_use[iclass].free_total;
+	}
+
+	// Span cache: free but still committed pages retained per page type
+	static const size_t page_type_size[4] = {SMALL_PAGE_SIZE, MEDIUM_SMALL_PAGE_SIZE, MEDIUM_LARGE_PAGE_SIZE,
+	                                          LARGE_PAGE_SIZE};
+	for (uint32_t itype = 0; itype < 4; ++itype)
+		stats->spancache += (size_t)heap->page_free_commit_count[itype] * page_type_size[itype];
+
+	// Per page type span use: current spans in use computed live (partial plus full), map calls counted
+	for (uint32_t itype = 0; itype < 5; ++itype) {
+		size_t current = 0;
+		if ((itype < 4) && heap->span_partial[itype])
+			++current;
+		for (span_t* span = heap->span_used[itype]; span; span = span->next)
+			++current;
+		stats->span_use[itype].current = current;
+		stats->span_use[itype].map_calls = (size_t)heap->span_map_calls[itype];
+	}
+#endif
+}
+
+void
 rpmalloc_dump_statistics(void* file) {
 #if ENABLE_STATISTICS
 	fprintf(file, "Mapped pages:        %llu\n",
@@ -2825,8 +2929,42 @@ rpmalloc_dump_statistics(void* file) {
 	        (unsigned long long)atomic_load_explicit(&global_statistics.huge_alloc, memory_order_relaxed));
 	fprintf(file, "Huge bytes (peak):   %llu\n",
 	        (unsigned long long)atomic_load_explicit(&global_statistics.huge_alloc_peak, memory_order_relaxed));
-	fprintf(file, "Heaps created:       %llu\n",
+	fprintf(file, "Heaps in use:        %llu\n",
 	        (unsigned long long)atomic_load_explicit(&global_statistics.heap_count, memory_order_relaxed));
+
+	// Aggregate per size class and per page type counters across all in-use heaps. This walks live
+	// heaps without stopping the world, so the values are a best-effort snapshot.
+	heap_size_use_t size_use[SIZE_CLASS_COUNT];
+	memset(size_use, 0, sizeof(size_use));
+	uint64_t span_map_calls[5];
+	memset(span_map_calls, 0, sizeof(span_map_calls));
+	heap_lock_acquire();
+	for (heap_t* heap = global_heap_used; heap; heap = heap->next) {
+		for (uint32_t iclass = 0; iclass < SIZE_CLASS_COUNT; ++iclass) {
+			size_use[iclass].alloc_current += heap->size_use[iclass].alloc_current;
+			size_use[iclass].alloc_peak += heap->size_use[iclass].alloc_peak;
+			size_use[iclass].alloc_total += heap->size_use[iclass].alloc_total;
+			size_use[iclass].free_total += heap->size_use[iclass].free_total;
+		}
+		for (uint32_t itype = 0; itype < 5; ++itype)
+			span_map_calls[itype] += heap->span_map_calls[itype];
+	}
+	heap_lock_release();
+
+	fprintf(file, "SizeClass  CurAlloc PeakAlloc  TotAlloc   TotFree BlockSize\n");
+	for (uint32_t iclass = 0; iclass < SIZE_CLASS_COUNT; ++iclass) {
+		if (!size_use[iclass].alloc_total)
+			continue;
+		fprintf(file, "%9u %9d %9d %9d %9d %9u\n", iclass, size_use[iclass].alloc_current,
+		        size_use[iclass].alloc_peak, size_use[iclass].alloc_total, size_use[iclass].free_total,
+		        global_size_class[iclass].block_size);
+	}
+	fprintf(file, "PageType  MapCalls\n");
+	for (uint32_t itype = 0; itype < 5; ++itype) {
+		if (!span_map_calls[itype])
+			continue;
+		fprintf(file, "%8u %9llu\n", itype, (unsigned long long)span_map_calls[itype]);
+	}
 #else
 	(void)sizeof(file);
 #endif

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -1901,9 +1901,8 @@ heap_allocate(int first_class) {
 		heap_lock_release();
 		heap->owner_thread = current_thread_id;
 #if ENABLE_STATISTICS
-		// Per-thread statistics start fresh for the new owner; a reused heap is not reinitialized
-		memset(heap->size_use, 0, sizeof(heap->size_use));
-		memset(heap->span_map_calls, 0, sizeof(heap->span_map_calls));
+		// Counters belong to the heap, not the thread, so alloc_current reflects the blocks live in
+		// the heap's pages regardless of which thread owns it.
 		atomic_fetch_add_explicit(&global_statistics.heap_count, 1, memory_order_relaxed);
 #endif
 	}
@@ -2875,14 +2874,16 @@ rpmalloc_thread_statistics(rpmalloc_thread_statistics_t* stats) {
 	if (!heap || (heap->id == 0))
 		return;
 
-	// Size class cache: free blocks held at heap level and in partially used pages, computed live
+	// Size class cache: blocks available without mapping a new page. A page's block_used counts the
+	// blocks held on the heap free list, so those are counted from the heap list and each page adds
+	// its remaining blocks (page free list plus the not yet initialized tail).
 	for (uint32_t iclass = 0; iclass < SIZE_CLASS_COUNT; ++iclass) {
 		size_t block_size = global_size_class[iclass].block_size;
 		size_t free_count = 0;
 		for (block_t* block = heap->local_free[iclass]; block; block = block->next)
 			++free_count;
 		for (page_t* page = heap->page_available[iclass]; page; page = page->next)
-			free_count += page->local_free_count;
+			free_count += (size_t)(page->block_count - page->block_used);
 		stats->sizecache += free_count * block_size;
 
 		stats->size_use[iclass].alloc_current = (size_t)heap->size_use[iclass].alloc_current;

--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -96,35 +96,19 @@ typedef struct rpmalloc_global_statistics_t {
 } rpmalloc_global_statistics_t;
 
 typedef struct rpmalloc_thread_statistics_t {
-	//! Current number of bytes available in thread size class caches for small and medium sizes (<32KiB)
+	//! Current number of bytes available in thread size class caches (only if ENABLE_STATISTICS=1)
 	size_t sizecache;
-	//! Current number of bytes available in thread span caches for small and medium sizes (<32KiB)
+	//! Current number of bytes available in thread page caches (only if ENABLE_STATISTICS=1)
 	size_t spancache;
-	//! Total number of bytes transitioned from thread cache to global cache (only if ENABLE_STATISTICS=1)
-	size_t thread_to_global;
-	//! Total number of bytes transitioned from global cache to thread cache (only if ENABLE_STATISTICS=1)
-	size_t global_to_thread;
-	//! Per span count statistics (only if ENABLE_STATISTICS=1)
+	//! Per page type span statistics, indexed by page type (small, medium-small, medium-large,
+	//! large, huge)
 	struct {
-		//! Currently used number of spans
+		//! Currently mapped number of spans of this page type
 		size_t current;
-		//! High water mark of spans used
-		size_t peak;
-		//! Number of spans transitioned to global cache
-		size_t to_global;
-		//! Number of spans transitioned from global cache
-		size_t from_global;
-		//! Number of spans transitioned to thread cache
-		size_t to_cache;
-		//! Number of spans transitioned from thread cache
-		size_t from_cache;
-		//! Number of spans transitioned to reserved state
-		size_t to_reserved;
-		//! Number of spans transitioned from reserved state
-		size_t from_reserved;
-		//! Number of raw memory map calls (not hitting the reserve spans but resulting in actual OS mmap calls)
+		//! Number of raw memory map calls for this page type resulting in actual OS mmap calls
+		//! (only if ENABLE_STATISTICS=1)
 		size_t map_calls;
-	} span_use[64];
+	} span_use[5];
 	//! Per size class statistics (only if ENABLE_STATISTICS=1)
 	struct {
 		//! Current number of allocations
@@ -135,14 +119,6 @@ typedef struct rpmalloc_thread_statistics_t {
 		size_t alloc_total;
 		//! Total number of frees
 		size_t free_total;
-		//! Number of spans transitioned to cache
-		size_t spans_to_cache;
-		//! Number of spans transitioned from cache
-		size_t spans_from_cache;
-		//! Number of spans transitioned from reserved state
-		size_t spans_from_reserved;
-		//! Number of raw memory map calls (not hitting the reserve spans but resulting in actual OS mmap calls)
-		size_t map_calls;
 	} size_use[128];
 } rpmalloc_thread_statistics_t;
 

--- a/test/main.c
+++ b/test/main.c
@@ -1466,6 +1466,90 @@ test_heap_packing(void) {
 #endif
 }
 
+static int
+test_thread_statistics(void) {
+	// Exercises rpmalloc_thread_statistics / rpmalloc_dump_statistics, which are otherwise never
+	// called by the suite. When ENABLE_STATISTICS is disabled the counters read back zero and the
+	// strict checks are skipped; the calls must still be safe.
+	rpmalloc_initialize(0);
+
+	rpmalloc_thread_statistics_t ts;
+	size_t base_current = 0, base_total = 0, base_free = 0;
+	rpmalloc_thread_statistics(&ts);
+	for (unsigned int i = 0; i < 128; ++i) {
+		base_current += ts.size_use[i].alloc_current;
+		base_total += ts.size_use[i].alloc_total;
+		base_free += ts.size_use[i].free_total;
+	}
+
+	enum { N = 100 };
+	void* ptr[N];
+	for (unsigned int i = 0; i < N; ++i) {
+		ptr[i] = rpmalloc(123);
+		if (!ptr[i])
+			return test_fail("Allocation failed in statistics test");
+	}
+
+	rpmalloc_thread_statistics(&ts);
+	size_t cur = 0, tot = 0, span_current = 0, span_maps = 0;
+	for (unsigned int i = 0; i < 128; ++i) {
+		cur += ts.size_use[i].alloc_current;
+		tot += ts.size_use[i].alloc_total;
+	}
+	for (unsigned int i = 0; i < 5; ++i) {
+		span_current += ts.span_use[i].current;
+		span_maps += ts.span_use[i].map_calls;
+	}
+
+	int stats_enabled = (tot > base_total);
+	if (stats_enabled) {
+		if ((cur - base_current) < N)
+			return test_fail("alloc_current did not reflect allocations");
+		if ((tot - base_total) < N)
+			return test_fail("alloc_total did not reflect allocations");
+		if (span_current < 1)
+			return test_fail("span current did not reflect mapped spans");
+		if (span_maps < 1)
+			return test_fail("span map_calls did not reflect mapped spans");
+		if (ts.sizecache == 0 && ts.spancache == 0) {
+			// At least the partially used page should hold free blocks
+			return test_fail("sizecache/spancache both zero after allocations");
+		}
+	}
+
+	for (unsigned int i = 0; i < N; ++i)
+		rpfree(ptr[i]);
+
+	rpmalloc_thread_statistics(&ts);
+	size_t cur2 = 0, free2 = 0;
+	for (unsigned int i = 0; i < 128; ++i) {
+		cur2 += ts.size_use[i].alloc_current;
+		free2 += ts.size_use[i].free_total;
+	}
+	if (stats_enabled) {
+		if (cur2 >= cur || (cur - cur2) < N)
+			return test_fail("alloc_current did not drop after free");
+		if ((free2 - base_free) < N)
+			return test_fail("free_total did not reflect frees");
+	}
+
+	// Dump must be safe to call (output discarded)
+	FILE* f = tmpfile();
+	if (f) {
+		rpmalloc_dump_statistics(f);
+		fclose(f);
+	}
+
+	rpmalloc_global_statistics_t gs;
+	rpmalloc_global_statistics(&gs);
+	if (stats_enabled && (gs.heap_count < 1))
+		return test_fail("heap_count should count in-use heaps");
+
+	rpmalloc_finalize();
+	printf("Thread statistics tests passed%s\n", stats_enabled ? "" : " (statistics disabled)");
+	return 0;
+}
+
 extern int
 test_malloc(int print_log);
 
@@ -1511,6 +1595,8 @@ test_run(int argc, char** argv) {
 	if (test_finalize_unmap())
 		return -1;
 	if (test_heap_packing())
+		return -1;
+	if (test_thread_statistics())
 		return -1;
 	printf("All tests passed\n");
 	return 0;


### PR DESCRIPTION
Define rpmalloc_thread_statistics (was declared but undefined) and add per size class
and per page type counters to the heap, with live size class / page cache reporting and a
breakdown in rpmalloc_dump_statistics. All per heap statistics are gated on ENABLE_STATISTICS,
adding no data or instructions when disabled, and the public statistics structs are unchanged
across the flag (zero filled when off). heap_count now reports heaps currently in use. Slim the
thread statistics struct to the fields this allocator populates and add a statistics test.