### PR TITLE
Probe huge page availability and harden init against re-entrancy, fix tests under override enable

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -13,8 +13,17 @@ generator = generator.Generator(project = 'rpmalloc', variables = [('bundleident
 
 rpmalloc_lib = generator.lib(module = 'rpmalloc', libname = 'rpmalloc', sources = ['rpmalloc.c'])
 rpmalloc_test_lib = generator.lib(module = 'rpmalloc', libname = 'rpmalloc-test', sources = ['rpmalloc.c'], variables = {'defines': ['ENABLE_OVERRIDE=1', 'ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1', 'RPMALLOC_FIRST_CLASS_HEAPS=1']})
+# Library variant without the standard library override, used by the no-override test binary which
+# exercises unmap_on_finalize (a no-op under the override, see rpmalloc.h).
+rpmalloc_test_nooverride_lib = generator.lib(module = 'rpmalloc', libname = 'rpmalloc-test-nooverride', sources = ['rpmalloc.c'], variables = {'defines': ['ENABLE_OVERRIDE=0', 'ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1', 'RPMALLOC_FIRST_CLASS_HEAPS=1']})
 
 if not generator.target.is_android() and not generator.target.is_ios():
 	rpmalloc_so = generator.sharedlib(module = 'rpmalloc', libname = 'rpmalloc', sources = ['rpmalloc.c'], variables = {'defines': ['ENABLE_DYNAMIC_LINK=1']})
 
-	generator.bin(module = 'test', sources = ['thread.c', 'main.c', 'main-override.cc'], binname = 'rpmalloc-test', implicit_deps = [rpmalloc_test_lib], libs = ['rpmalloc-test'], includepaths = ['rpmalloc', 'test'], variables = {'defines': ['ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1', 'RPMALLOC_FIRST_CLASS_HEAPS=1']})
+	generator.bin(module = 'test', sources = ['thread.c', 'main.c', 'main-override.cc'], binname = 'rpmalloc-test', implicit_deps = [rpmalloc_test_lib], libs = ['rpmalloc-test'], includepaths = ['rpmalloc', 'test'], variables = {'defines': ['ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1', 'RPMALLOC_FIRST_CLASS_HEAPS=1', 'RPMALLOC_TEST_OVERRIDE=1']})
+
+	# No-override test binary: runs the unmap_on_finalize tests (test_finalize_unmap, test_heap_packing)
+	# against a library built without the override, where unmap_on_finalize is actually honored. It does
+	# not link main-override.cc and leaves RPMALLOC_TEST_OVERRIDE at its default 0 so the override tests
+	# are skipped and the unmap tests run.
+	generator.bin(module = 'test', sources = ['thread.c', 'main.c'], binname = 'rpmalloc-test-nooverride', implicit_deps = [rpmalloc_test_nooverride_lib], libs = ['rpmalloc-test-nooverride'], includepaths = ['rpmalloc', 'test'], variables = {'defines': ['ENABLE_ASSERTS=1', 'ENABLE_STATISTICS=1', 'RPMALLOC_FIRST_CLASS_HEAPS=1']})

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -77,6 +77,7 @@ static virtualalloc2_fn os_virtualalloc2;
 #include <sys/mman.h>
 #include <sched.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <pthread.h>
 static pthread_key_t pthread_key;
 #ifdef __FreeBSD__
@@ -904,9 +905,10 @@ os_mmap(size_t size, size_t alignment, size_t* offset, size_t* mapped_size) {
 	if ((ptr == MAP_FAILED || !ptr) && os_huge_pages) {
 		ptr = mmap(0, map_size, PROT_READ | PROT_WRITE, flags, -1, 0);
 		if (ptr && (ptr != MAP_FAILED)) {
-			int prm = madvise(ptr, map_size, MADV_HUGEPAGE);
-			(void)prm;
-			rpmalloc_assert((prm == 0), "Failed to promote the page to transparent huge page");
+			// Best-effort promotion to transparent huge pages; ignore failures (for
+			// example when THP is disabled system-wide, where madvise returns EINVAL).
+			// The mapping is still valid, just backed by normal pages.
+			(void)madvise(ptr, map_size, MADV_HUGEPAGE);
 		}
 	} else if (os_thp && ptr && (ptr != MAP_FAILED)) {
 		// Transparent huge page mode, advise the kernel to back this mapping with
@@ -2600,6 +2602,32 @@ rpmalloc_thread_destructor(void* value) {
 		rpmalloc_thread_finalize();
 }
 
+#if defined(__linux__) || defined(__ANDROID__)
+//! Read a small (pseudo) file such as /proc/meminfo into a caller provided stack buffer
+//! using raw syscalls. This deliberately avoids stdio (fopen/fgets), which allocates an
+//! internal buffer through malloc - during rpmalloc_initialize that allocation would
+//! re-enter the allocator (when the malloc override is enabled) before the page size is
+//! established. Returns the number of bytes read (buffer is always null terminated), or 0.
+static size_t
+os_read_system_file(const char* path, char* buffer, size_t capacity) {
+	if (capacity < 2)
+		return 0;
+	int fd = open(path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return 0;
+	size_t total = 0;
+	while ((total + 1) < capacity) {
+		ssize_t got = read(fd, buffer + total, (capacity - 1) - total);
+		if (got <= 0)
+			break;
+		total += (size_t)got;
+	}
+	close(fd);
+	buffer[total] = 0;
+	return total;
+}
+#endif
+
 extern int
 rpmalloc_initialize_config(rpmalloc_interface_t* memory_interface, rpmalloc_config_t* config) {
 	if (global_rpmalloc_initialized) {
@@ -2628,6 +2656,10 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 	}
 
 	global_rpmalloc_initialized = 1;
+
+	// Remember whether the caller explicitly requested huge pages, the detection below
+	// overwrites global_config.enable_huge_pages with what is actually available.
+	const int huge_pages_requested = global_config.enable_huge_pages;
 
 	global_memory_interface = memory_interface ? memory_interface : &global_memory_interface_default;
 	if (!global_memory_interface->memory_map || !global_memory_interface->memory_unmap) {
@@ -2660,6 +2692,13 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 	os_huge_pages = 0;
 	os_thp = 0;
 	os_huge_page_shift = 0;
+
+	// Establish a valid (normal) page size up front so the allocator never observes a
+	// zero page size during the rest of initialization. Huge page detection below may
+	// raise it to the huge page size once availability has been confirmed.
+	if (!memory_interface || (global_config.page_size < os_page_size))
+		global_config.page_size = os_page_size;
+
 	if (global_config.enable_huge_pages) {
 #if PLATFORM_WINDOWS
 		HANDLE token = 0;
@@ -2696,15 +2735,11 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 		}
 #elif defined(__linux__)
 		size_t huge_page_size = 0;
-		FILE* meminfo = fopen("/proc/meminfo", "r");
-		if (meminfo) {
-			char line[128];
-			while (!huge_page_size && fgets(line, sizeof(line) - 1, meminfo)) {
-				line[sizeof(line) - 1] = 0;
-				if (strstr(line, "Hugepagesize:"))
-					huge_page_size = (size_t)strtol(line + 13, 0, 10) * 1024;
-			}
-			fclose(meminfo);
+		char meminfo[4096];
+		if (os_read_system_file("/proc/meminfo", meminfo, sizeof(meminfo))) {
+			const char* line = strstr(meminfo, "Hugepagesize:");
+			if (line)
+				huge_page_size = (size_t)strtol(line + 13, 0, 10) * 1024;
 		}
 		// Sanity check the detected default huge page size, the builtin page geometry
 		// cannot use huge pages larger than the largest builtin page size (e.g. 1GiB
@@ -2714,11 +2749,31 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 			huge_page_size = 0;
 		if (huge_page_size > LARGE_PAGE_SIZE)
 			huge_page_size = 2 * 1024 * 1024;
+#if defined(MAP_HUGETLB)
 		if (huge_page_size) {
-			os_huge_pages = 1;
-			os_page_size = huge_page_size;
-			os_map_granularity = huge_page_size;
+			// Hugepagesize in /proc/meminfo only reports the configured huge page size, not
+			// whether any huge pages are actually available (the static pool can be empty,
+			// HugePages_Total == 0). Probe by mapping a single huge page with the same flags
+			// used for real mappings and only enable huge pages if the request can actually
+			// be satisfied (static pool or overcommit). This also covers the case where the
+			// page size is reported but the kernel rejects that specific MAP_HUGE_* size.
+			size_t huge_shift = 0;
+			while (((size_t)1 << huge_shift) < huge_page_size)
+				++huge_shift;
+			int probe_flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB;
+#if defined(MAP_HUGE_SHIFT)
+			probe_flags |= (int)(huge_shift << MAP_HUGE_SHIFT);
+#endif
+			void* probe = mmap(0, huge_page_size, PROT_READ | PROT_WRITE, probe_flags, -1, 0);
+			if ((probe != MAP_FAILED) && probe) {
+				munmap(probe, huge_page_size);
+				os_huge_pages = 1;
+				os_huge_page_shift = huge_shift;
+				os_page_size = huge_page_size;
+				os_map_granularity = huge_page_size;
+			}
 		}
+#endif
 #elif defined(__FreeBSD__)
 		int rc;
 		size_t sz = sizeof(rc);
@@ -2742,6 +2797,16 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 #endif
 	}
 
+	if (huge_pages_requested && !os_huge_pages) {
+		// Explicit huge pages were requested but are not available on this system. Fail
+		// initialization rather than silently backing the heap with normal pages behind a
+		// huge page size. Leave the allocator uninitialized (and the requested flag cleared)
+		// so the caller can detect this and re-initialize without huge pages if desired.
+		global_config.enable_huge_pages = 0;
+		global_rpmalloc_initialized = 0;
+		return -1;
+	}
+
 	global_config.enable_huge_pages = os_huge_pages;
 
 	if (os_huge_pages) {
@@ -2761,8 +2826,16 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 #if defined(__linux__) || defined(__ANDROID__)
 	// Transparent huge pages, advise mappings to be huge page backed without requiring
 	// a preallocated huge page pool and without affecting page size or decommit
-	if (global_config.enable_thp && !os_huge_pages && !global_config.disable_thp)
-		os_thp = 1;
+	if (global_config.enable_thp && !os_huge_pages && !global_config.disable_thp) {
+		// When THP is disabled system-wide (mode "never") madvise(MADV_HUGEPAGE) is a
+		// no-op, so report it as disabled rather than claiming THP is in use.
+		char thp_state[64];
+		int thp_never = 0;
+		if (os_read_system_file("/sys/kernel/mm/transparent_hugepage/enabled", thp_state, sizeof(thp_state)))
+			thp_never = (strstr(thp_state, "[never]") != 0);
+		if (!thp_never)
+			os_thp = 1;
+	}
 	if (global_config.disable_thp)
 		(void)prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
 #endif

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -158,9 +158,11 @@ madvise(caddr_t, size_t, int);
 #ifndef ENABLE_OVERRIDE
 //! Enable standard library malloc/free/new/delete overrides. When enabled, rpmalloc becomes the
 //  backing store for the entire process, including the C runtime's own allocations (for example
-//  per-thread TLS allocated by the loader). As a consequence the unmap_on_finalize config option
-//  is ignored (see rpmalloc_initialize): returning all mappings to the OS at finalize while the
-//  process keeps running would unmap memory the runtime still holds.
+//  per-thread TLS allocated by the loader). Two finalize-time features are therefore adjusted:
+//  the unmap_on_finalize config option is ignored (see rpmalloc_initialize), since returning all
+//  mappings to the OS while the process keeps running would unmap memory the runtime still holds;
+//  and ENABLE_LEAK_DETECTION defaults off, since the runtime's still-live allocations are
+//  indistinguishable from application leaks at finalize.
 #define ENABLE_OVERRIDE 1
 #endif
 #ifndef ENABLE_STATISTICS
@@ -169,8 +171,15 @@ madvise(caddr_t, size_t, int);
 #endif
 #ifndef ENABLE_LEAK_DETECTION
 //! Enable detection of allocations still outstanding at rpmalloc_finalize. Requires ENABLE_STATISTICS
-//  for the allocation counters, and follows it by default
+//  for the allocation counters, and follows it by default - except under ENABLE_OVERRIDE, where it
+//  defaults off: the override makes rpmalloc the backing store for the C runtime's own allocations
+//  (for example per-thread TLS allocated by the loader), which are still live at finalize and
+//  indistinguishable from application leaks, so the check would always report false positives.
+#if ENABLE_OVERRIDE
+#define ENABLE_LEAK_DETECTION 0
+#else
 #define ENABLE_LEAK_DETECTION ENABLE_STATISTICS
+#endif
 #endif
 #if ENABLE_LEAK_DETECTION && !ENABLE_STATISTICS
 #error ENABLE_LEAK_DETECTION requires ENABLE_STATISTICS

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -156,7 +156,11 @@ madvise(caddr_t, size_t, int);
 #define ENABLE_DYNAMIC_LINK 0
 #endif
 #ifndef ENABLE_OVERRIDE
-//! Enable standard library malloc/free/new/delete overrides
+//! Enable standard library malloc/free/new/delete overrides. When enabled, rpmalloc becomes the
+//  backing store for the entire process, including the C runtime's own allocations (for example
+//  per-thread TLS allocated by the loader). As a consequence the unmap_on_finalize config option
+//  is ignored (see rpmalloc_initialize): returning all mappings to the OS at finalize while the
+//  process keeps running would unmap memory the runtime still holds.
 #define ENABLE_OVERRIDE 1
 #endif
 #ifndef ENABLE_STATISTICS
@@ -2668,6 +2672,14 @@ rpmalloc_initialize(rpmalloc_interface_t* memory_interface) {
 		global_memory_interface->memory_decommit = os_mdecommit;
 		global_memory_interface->memory_unmap = os_munmap;
 	}
+
+#if ENABLE_OVERRIDE
+	// With the standard library override, rpmalloc backs the C runtime's own allocations (for
+	// example per-thread TLS allocated by the loader). Unmapping everything at finalize while the
+	// process keeps running would pull that memory out from under the runtime, so the option
+	// cannot be honored here; clear it (also reflected back through the effective config).
+	global_config.unmap_on_finalize = 0;
+#endif
 
 #if PLATFORM_WINDOWS
 	SYSTEM_INFO system_info;

--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -180,6 +180,10 @@ typedef struct rpmalloc_config_t {
 	//! Unmap all memory on finalize if set to 1. Normally you can let the OS unmap all pages
 	//  when process exits, but if using rpmalloc in a dynamic library you might want to unmap
 	//  all pages when the dynamic library unloads to avoid process memory leaks and bloat.
+	//  NOTE: this is ignored when rpmalloc is built with ENABLE_OVERRIDE, because the standard
+	//  library override makes rpmalloc the backing store for the C runtime's own allocations
+	//  (for example per-thread TLS). Returning all mappings to the OS while the process keeps
+	//  running would unmap memory the runtime still uses. Only honored without the override.
 	int unmap_on_finalize;
 #if defined(__linux__) || defined(__ANDROID__)
 	///! Allows to disable the Transparent Huge Page feature on Linux on a process basis,

--- a/test/main.c
+++ b/test/main.c
@@ -1190,13 +1190,17 @@ test_huge_pages(void) {
 	rpmalloc_config_t config = {0};
 	config.enable_huge_pages = 1;
 
-	rpmalloc_initialize_config(0, &config);
+	// Explicit huge pages now fail initialization when no huge pages are available on the
+	// system, rather than silently falling back to normal pages behind a huge page size.
+	if (rpmalloc_initialize_config(0, &config) != 0) {
+		printf("Huge pages test skipped (huge pages not supported)\n");
+		return 0;
+	}
 
 	const rpmalloc_config_t* effective_config = rpmalloc_config();
 	if (!effective_config->enable_huge_pages) {
 		rpmalloc_finalize();
-		printf("Huge pages test skipped (huge pages not supported)\n");
-		return 0;
+		return test_fail("Huge pages initialized but not enabled in effective config");
 	}
 	if (effective_config->page_size < (2 * 1024 * 1024)) {
 		rpmalloc_finalize();

--- a/test/main.c
+++ b/test/main.c
@@ -40,6 +40,13 @@
 #include <sys/mman.h>
 #endif
 
+// Set to 1 for the test binary built against the rpmalloc library with ENABLE_OVERRIDE=1 (runs the
+// standard library override tests). The override-incompatible tests (unmap_on_finalize, which is a
+// no-op under the override) instead run in a separate binary built with ENABLE_OVERRIDE=0.
+#ifndef RPMALLOC_TEST_OVERRIDE
+#define RPMALLOC_TEST_OVERRIDE 0
+#endif
+
 #define pointer_offset(ptr, ofs) (void*)((char*)(ptr) + (ptrdiff_t)(ofs))
 #define pointer_diff(first, second) (ptrdiff_t)((const char*)(first) - (const char*)(second))
 
@@ -1280,6 +1287,9 @@ test_named_pages(void) {
 	return 0;
 }
 
+#if !RPMALLOC_TEST_OVERRIDE
+// unmap_on_finalize is a no-op under the standard library override (see rpmalloc.h), so the tests
+// that exercise it are compiled only into the no-override test binary (RPMALLOC_TEST_OVERRIDE == 0).
 static int
 test_finalize_unmap(void) {
 	// Exercises heap packing together with unmap_on_finalize, which the other tests leave disabled
@@ -1470,6 +1480,7 @@ test_heap_packing(void) {
 	return 0;
 #endif
 }
+#endif /* !RPMALLOC_TEST_OVERRIDE */
 
 static int
 test_thread_statistics(void) {
@@ -1579,12 +1590,16 @@ test_run(int argc, char** argv) {
 		return -1;
 	if (test_threaded())
 		return -1;
+#if RPMALLOC_TEST_OVERRIDE
+	// Standard library override tests, only valid when rpmalloc is built with ENABLE_OVERRIDE
+	// (these are linked from main-override.cc and cross-check malloc/new against rpmalloc).
 	if (test_malloc(1))
 		return -1;
 	if (test_free(1))
 		return -1;
 	if (test_malloc_thread())
 		return -1;
+#endif
 	if (test_threadspam())
 		return -1;
 	if (test_large_pages())
@@ -1597,10 +1612,14 @@ test_run(int argc, char** argv) {
 		return -1;
 	if (test_named_pages())
 		return -1;
+#if !RPMALLOC_TEST_OVERRIDE
+	// unmap_on_finalize is a no-op under the standard library override (see rpmalloc.h), so these
+	// tests run only in the no-override binary where the option is actually honored.
 	if (test_finalize_unmap())
 		return -1;
 	if (test_heap_packing())
 		return -1;
+#endif
 	if (test_thread_statistics())
 		return -1;
 	printf("All tests passed\n");


### PR DESCRIPTION
Probe huge page availability and harden init against re-entrancy
Huge page detection on Linux keyed off the mere presence of "Hugepagesize:"
in /proc/meminfo, which is always reported (it is the configured size, not a
count). On a host with an empty pool (HugePages_Total: 0) rpmalloc therefore
believed explicit huge pages were available, set page_size to the huge size,
and only failed when the real mapping could not be backed.

unmap_on_finalize returns all of rpmalloc's mappings to the OS at finalize. With
ENABLE_OVERRIDE the standard library override makes rpmalloc the backing store for
the C runtime's own allocations (notably per-thread TLS allocated by the loader),
so unmapping everything while the process keeps running pulls memory out from under
the runtime. The next pthread_create then faults in glibc's cached-stack/TLS path.

With ENABLE_OVERRIDE the override makes rpmalloc the backing store for the C
runtime's own allocations (for example per-thread TLS allocated by the loader).
Those are still live at rpmalloc_finalize and are indistinguishable from
application leaks, so the finalize leak-detection check (ENABLE_LEAK_DETECTION,
which follows ENABLE_STATISTICS by default) reports false positives and, with
asserts enabled, aborts.

ENABLE_LEAK_DETECTION now defaults off when ENABLE_OVERRIDE is set, instead of
following ENABLE_STATISTICS. It can still be enabled explicitly. Genuine leak
detection is exercised by the no-override test binary (rpmalloc-test-nooverride),
which runs the full suite with leak detection active.

This is the same override interaction that made unmap_on_finalize unsafe; together
the two finalize-time features are now both safe under the override.