### PR TITLE
Fix Linguist language stats (vendor build scripts recursively)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,9 @@
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
 
-# Ignore build scripts and test cases in language stats
-build/* linguist-vendored
-configure.py linguist-vendored=true
-test/* linguist-vendored
+# Ignore build scripts, benchmark tooling and test cases in language stats.
+# Use ** so the patterns recurse into subdirectories (build/ninja/, build/msvs/, ...).
+build/** linguist-vendored
+configure.py linguist-vendored
+benchmark/*.py linguist-vendored
+test/** linguist-vendored


### PR DESCRIPTION
Fix GitHub language stats showing the project as largely Python.

The build scripts live in `build/ninja/*.py`, but the existing `build/* linguist-vendored` rule did not match them - in gitattributes `*` does not cross `/`, so only files directly in `build/` were vendored. Switch to recursive `**` patterns (`build/**`, `test/**`) and also vendor `benchmark/*.py` and `configure.py`, so Linguist counts the C library (`rpmalloc/`) rather than the Python build tooling.

Verified with `git check-attr`: build/ninja scripts, MSVS project files, benchmark and test files are now vendored; `rpmalloc/*.c` remain counted.