### PR TITLE
Assert custom memory_map returns span-aligned blocks

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -2024,6 +2024,8 @@ heap_get_span(heap_t* heap, page_type_t page_type) {
 	heap->stats.mapped_size += mapped_size;
 #endif
 	if (EXPECTED(span != 0)) {
+		rpmalloc_assert(!((uintptr_t)span & (SPAN_SIZE - 1)),
+		                "memory_map returned a block not aligned to the span size");
 		_rpmalloc_stat_inc_span_map(heap, page_type);
 		uint32_t page_count = 0;
 		uint32_t page_size = 0;
@@ -2200,6 +2202,8 @@ heap_allocate_block_huge(heap_t* heap, size_t size, unsigned int zero) {
 		block = global_memory_interface->memory_map(alloc_size, SPAN_SIZE, &offset, &mapped_size);
 	if (block) {
 		span_t* span = block;
+		rpmalloc_assert(!((uintptr_t)span & (SPAN_SIZE - 1)),
+		                "memory_map returned a block not aligned to the span size");
 		if (!from_cache)
 			_rpmalloc_stat_inc_span_map(heap, PAGE_HUGE);
 #if ENABLE_DECOMMIT


### PR DESCRIPTION
Addresses concern (1) of #287.

The allocator requires mapped spans (and huge blocks) to be aligned to the span size - the free path locates the span/page headers by masking the block address (`(span_t*)((uintptr_t)block & SPAN_MASK)`), so a misaligned custom `memory_map` silently corrupts. The requirement is documented in `rpmalloc.h`/README but was unenforced even with `ENABLE_ASSERTS` (the only alignment assert lived inside the default `os_mmap`, checking its own padding).

This adds an `rpmalloc_assert` after the two aligning `memory_map` call sites (span map and huge alloc) so a custom mapper returning a misaligned block is caught in debug builds - invaluable on platforms where custom mapping is the norm (e.g. the reporter's consoles).

The other #287 concerns are already resolved by the develop memory-interface redesign: `memory_map` now receives the required alignment as a parameter (custom mappers no longer need the internal granularity exposed), and the map offset is a full `size_t` with no `UINT16_MAX` constraint.

Verified: clean build under `-Weverything`; full test suite passes with asserts enabled.